### PR TITLE
Revert "bump code coverage target and enable workflow to fail when below target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,10 +34,10 @@ jobs:
       with:
         filename: coverage/aai-portal/cobertura.txt
         badge: true
-        fail_below_min: true
+        fail_below_min: false
         format: markdown
         hide_branch_rate: true
         hide_complexity: true
         indicators: true
         output: console
-        thresholds: '90 90'
+        thresholds: '60 80'


### PR DESCRIPTION


This reverts commit 63c39e5161ea60fd1935fd82de5b1e679a5004e5.