### PR TITLE
AAI-194: bump code coverage target and enable workflow to fail when below target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,10 +34,10 @@ jobs:
       with:
         filename: coverage/aai-portal/cobertura.txt
         badge: true
-        fail_below_min: false
+        fail_below_min: true
         format: markdown
         hide_branch_rate: true
         hide_complexity: true
         indicators: true
         output: console
-        thresholds: '60 80'
+        thresholds: '90 90'


### PR DESCRIPTION
## Description

[AAI-194](https://biocloud.atlassian.net/browse/AAI-149): bump up test coverage to 90% and enable workflow to fail when target coverage not reached.

## Changes

- bump up test coverage to 90% in Github action workflow file
-  in Github action workflow file, enable workflow to fail when target coverage not reached

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)