### PR TITLE
AAI-150: improve app tests to test behaviour

### DIFF
--- a/src/app/layouts/navbar/navbar.component.spec.ts
+++ b/src/app/layouts/navbar/navbar.component.spec.ts
@@ -4,8 +4,9 @@ import { NavbarComponent } from './navbar.component';
 import {provideHttpClient} from '@angular/common/http';
 import {provideRouter} from '@angular/router';
 import {provideMockAuth0Service} from '../../../utils/testingUtils';
+import {By} from '@angular/platform-browser';
 
-describe('NavbarComponent', () => {
+describe('NavbarComponent when logged in', () => {
   let component: NavbarComponent;
   let fixture: ComponentFixture<NavbarComponent>;
 
@@ -13,7 +14,7 @@ describe('NavbarComponent', () => {
     await TestBed.configureTestingModule({
       imports: [NavbarComponent],
       providers: [
-        provideMockAuth0Service(),
+        provideMockAuth0Service({isAuthenticated: true}),
         provideHttpClient(),
         provideRouter([])],
     })
@@ -26,5 +27,35 @@ describe('NavbarComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('Should display Dashboard nav', () => {
+    const navDe = fixture.debugElement;
+    const header = navDe.query(By.css('.text-2xl'))
+    expect(header.nativeElement.textContent).toContain('Dashboard');
+  })
+});
+describe('NavbarComponent when logged out', () => {
+  let component: NavbarComponent;
+  let fixture: ComponentFixture<NavbarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NavbarComponent],
+      providers: [
+        provideMockAuth0Service({isAuthenticated: false}),
+        provideHttpClient(),
+        provideRouter([])],
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(NavbarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should ask to log in', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('p')!.textContent).toMatch('Please log in to continue');
   });
 });

--- a/src/app/pages/user/services/request-service/request-service.component.html
+++ b/src/app/pages/user/services/request-service/request-service.component.html
@@ -44,10 +44,11 @@
                 <div
                   class="flex items-center justify-between gap-12 rounded-md bg-white p-5 font-light"
                 >
-                  <div class="text-gray-500">{{ system.name }}</div>
+                  <div class="text-gray-500" id="{{ system.id}}-label">{{ system.name }}</div>
                   <input
                     type="checkbox"
                     value=""
+                    name="{{ system.id }}"
                     [formControlName]="system.id"
                     class="h-6 w-6 shrink-0 rounded-md border border-sky-900"
                   />

--- a/src/app/pages/user/services/request-service/request-service.component.spec.ts
+++ b/src/app/pages/user/services/request-service/request-service.component.spec.ts
@@ -1,9 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { RequestServiceComponent } from './request-service.component';
-import {provideMockAuth0Service} from '../../../../../utils/testingUtils';
+import {provideMockAuth0Service, provideMockAuthService} from '../../../../../utils/testingUtils';
 import {provideHttpClient} from '@angular/common/http';
 import {provideRouter} from '@angular/router';
+import { By } from '@angular/platform-browser';
 
 describe('RequestServiceComponent', () => {
   let component: RequestServiceComponent;
@@ -24,4 +25,48 @@ describe('RequestServiceComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+});
+
+describe('RequestServiceComponent with existing user', () => {
+  let component: RequestServiceComponent;
+  let fixture: ComponentFixture<RequestServiceComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RequestServiceComponent],
+      providers: [
+        // Set mock user with some systems already approved
+        provideMockAuthService({
+          isAuthenticated: true,
+          user: {
+            user_metadata: {systems: {approved: ["TSI_SH", "BPA_DP"], requested: ["GX_AU"]}}}
+        }),
+        provideHttpClient(),
+        provideRouter([])]
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(RequestServiceComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should show remaining systems in form', () => {
+    const debugEl = fixture.debugElement;
+    const control = debugEl.query(By.css('input[name="SBP"]'));
+    expect(control).not.toBeNull();
+    const label = debugEl.query(By.css('#SBP-label'));
+    expect(label.nativeElement.textContent).toContain('Structural Biology Platform');
+  });
+
+  it('approved and requested systems should not be shown', () => {
+    const debugEl = fixture.debugElement;
+    console.log(fixture.componentInstance.user)
+    console.log(fixture.componentInstance.remainingSystems);
+    console.log(fixture.componentInstance.selectedSystems);
+    const approved_system = debugEl.query(By.css('input[name="TSI_SH"]'));
+    expect(approved_system).toBeNull();
+    const requested_system = debugEl.query(By.css('input[name="GX_AU"]'));
+    expect(requested_system).toBeNull();
+  })
 });

--- a/src/app/pages/user/services/request-service/request-service.component.spec.ts
+++ b/src/app/pages/user/services/request-service/request-service.component.spec.ts
@@ -15,7 +15,7 @@ describe('RequestServiceComponent', () => {
       imports: [RequestServiceComponent],
       providers: [provideMockAuth0Service(), provideHttpClient(), provideRouter([])]
     })
-    .compileComponents();
+      .compileComponents();
 
     fixture = TestBed.createComponent(RequestServiceComponent);
     component = fixture.componentInstance;

--- a/src/app/pages/user/services/request-service/request-service.component.ts
+++ b/src/app/pages/user/services/request-service/request-service.component.ts
@@ -43,7 +43,7 @@ export class RequestServiceComponent implements OnInit {
         const excludedSystemIDs = [...approvedSystemIDs, ...requestedSystemIDs];
 
         this.remainingSystems = systemsList.filter(
-          (system: any) => !excludedSystemIDs.includes(system.id),
+          (system) => !excludedSystemIDs.includes(system.id),
         );
 
         // Dynamically add form controls for each remaining system

--- a/src/app/shared/components/buttons/logout-button/logout-button.component.spec.ts
+++ b/src/app/shared/components/buttons/logout-button/logout-button.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { LogoutButtonComponent } from './logout-button.component';
 import {provideMockAuth0Service} from '../../../../../utils/testingUtils';
 import {provideHttpClient} from '@angular/common/http';
+import {By} from '@angular/platform-browser';
 
 describe('LogoutButtonComponent', () => {
   let component: LogoutButtonComponent;
@@ -11,7 +12,7 @@ describe('LogoutButtonComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [LogoutButtonComponent],
-      providers: [provideMockAuth0Service(), provideHttpClient()]
+      providers: [provideMockAuth0Service({isAuthenticated: true}), provideHttpClient()]
     })
     .compileComponents();
 
@@ -22,5 +23,12 @@ describe('LogoutButtonComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should call logout() on click", () => {
+    let logoutFunction = spyOn(component, 'logout');
+    const button = fixture.nativeElement.querySelector('button');
+    button.click();
+    expect(logoutFunction).toHaveBeenCalled();
   });
 });

--- a/src/utils/testingUtils.ts
+++ b/src/utils/testingUtils.ts
@@ -1,17 +1,38 @@
 import {of} from 'rxjs';
 import {AuthService as Auth0Service} from '@auth0/auth0-angular';
+import { UserWithMetadata } from '../app/core/services/auth.service';
+import {AuthService} from '../app/core/services/auth.service';
+import { signal } from '@angular/core';
 
 /**
  * Mock version of the AuthService from Auth0 that can be used in tests
  * when components depend on this service. Can be passed to the providers
  * field when configuring TestBed
  */
-export function provideMockAuth0Service(options: {isAuthenticated: boolean } = {isAuthenticated: true}) {
+export function provideMockAuth0Service(options: {isAuthenticated: boolean,  user?: UserWithMetadata} = {isAuthenticated: true}) {
+  const user = options.user || { name: 'TestUser'};
   const mockAuth0Service = {
     isAuthenticated$: of(options.isAuthenticated),
-    user$: of({ name: 'Test User' }),
+    user$: of(user),
     loginWithRedirect: jasmine.createSpy('loginWithRedirect'),
     logout: jasmine.createSpy('logout'),
   };
   return {provide: Auth0Service, useValue: mockAuth0Service};
+}
+
+/**
+ * Mock version of our AuthService that can be used in testing
+ * when components depend on it.
+ *
+ * Pass this to the providers field when configuring TestBed.
+ *
+ * Pass data to options to set up the AuthService with specific values
+ * and user data
+ *
+ */
+export function provideMockAuthService(options: {isAuthenticated: boolean,  user?: UserWithMetadata}) {
+  const user = options.user || { name: 'TestUser'};
+  const userSignal = signal(user);
+  const mockAuthService = jasmine.createSpyObj('AuthService', {getUser: of(user)}, {isAuthenticated: signal(options.isAuthenticated), user: userSignal, user$: of(userSignal)});
+  return {provide: AuthService, useValue: mockAuthService};
 }

--- a/src/utils/testingUtils.ts
+++ b/src/utils/testingUtils.ts
@@ -6,9 +6,9 @@ import {AuthService as Auth0Service} from '@auth0/auth0-angular';
  * when components depend on this service. Can be passed to the providers
  * field when configuring TestBed
  */
-export function provideMockAuth0Service() {
+export function provideMockAuth0Service(options: {isAuthenticated: boolean } = {isAuthenticated: true}) {
   const mockAuth0Service = {
-    isAuthenticated$: of(true),
+    isAuthenticated$: of(options.isAuthenticated),
     user$: of({ name: 'Test User' }),
     loginWithRedirect: jasmine.createSpy('loginWithRedirect'),
     logout: jasmine.createSpy('logout'),


### PR DESCRIPTION
## Description

[AAI-150](https://biocloud.atlassian.net/browse/AAI-150): trying to write meaningful tests of the app so that we test desired behaviour. These tests are fairly simple for now, but provide examples we can build on for more complex tests if needed

## Changes

- Create mock auth services to allow testing of components that depend on them
- Allow setting `isAuthenticated` in the mock auth service for tests of logged in vs. logged out behaviour
- Allow setting user data and metadata in the mock auth service to test components that depend on this data
- Test navbar component has expected content when logged in vs logged out
- Test that `request-service` component shows the expected services based on what is approved/pending/remaining

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

## How to Test Manually

Run `ng test`



[AAI-150]: https://biocloud.atlassian.net/browse/AAI-150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ