### PR TITLE
AAI-166 submit Galaxy registration data to backend

### DIFF
--- a/src/app/pages/galaxy/register/galaxy-register.component.html
+++ b/src/app/pages/galaxy/register/galaxy-register.component.html
@@ -1,5 +1,16 @@
 <div class="max-w-xl mx-auto p-6 bg-white shadow-md rounded-md my-4 gap-2">
   <h1 class="font-semibold">Create a Galaxy account</h1>
+  @if (registerSuccess) {
+    <div id="register_success_message" class="m-2 mb-4 p-2 bg-green-100 border border-green-800 rounded text-black text-sm">
+      Registration successful! Please <strong>check your email</strong> and confirm your email
+      address before <a class="font-semibold underline" href="https://galaxy.test.biocommons.org.au">signing in to Galaxy</a>
+    </div>
+  }
+  @if (errorMessage !== null) {
+    <div id="register_error_message" class="m-2 mb-4 p-2 bg-red-100 border border-red-800 rounded text-black text-sm">
+      Registration failed: {{ errorMessage }}
+    </div>
+  }
   <div class="m-2 mb-4 p-2 bg-blue-300 bg-opacity-50 rounded text-blue-900 text-sm">
     Please register only one account to ensure fair sharing of computational resources.
     Multiple registrations are monitored and will result in account termination and data deletion.

--- a/src/app/pages/galaxy/register/galaxy-register.component.spec.ts
+++ b/src/app/pages/galaxy/register/galaxy-register.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { ReactiveFormsModule } from '@angular/forms';
 import { GalaxyRegisterComponent } from './galaxy-register.component';
 import { provideHttpClient } from '@angular/common/http';
-import { HttpClientTestingModule, HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { By } from '@angular/platform-browser';
 
 describe('GalaxyRegisterComponent', () => {

--- a/src/app/pages/galaxy/register/galaxy-register.component.spec.ts
+++ b/src/app/pages/galaxy/register/galaxy-register.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { GalaxyRegisterComponent } from './galaxy-register.component';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('GalaxyRegisterComponent', () => {
   let component: GalaxyRegisterComponent;
@@ -8,7 +9,8 @@ describe('GalaxyRegisterComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ReactiveFormsModule, GalaxyRegisterComponent]
+      imports: [ReactiveFormsModule, GalaxyRegisterComponent],
+      providers: [provideHttpClient()]
     }).compileComponents();
 
     fixture = TestBed.createComponent(GalaxyRegisterComponent);

--- a/src/app/pages/galaxy/register/galaxy-register.component.spec.ts
+++ b/src/app/pages/galaxy/register/galaxy-register.component.spec.ts
@@ -1,7 +1,9 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { GalaxyRegisterComponent } from './galaxy-register.component';
 import { provideHttpClient } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { By } from '@angular/platform-browser';
 
 describe('GalaxyRegisterComponent', () => {
   let component: GalaxyRegisterComponent;
@@ -75,5 +77,108 @@ describe('GalaxyRegisterComponent', () => {
       return e.textContent?.includes('Your public name should contain only');
     });
     expect(patternError).toBeTruthy();
+  });
+});
+
+describe('GalaxyRegisterComponent submission', () => {
+  let component: GalaxyRegisterComponent;
+  let fixture: ComponentFixture<GalaxyRegisterComponent>;
+  let httpMock: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule, GalaxyRegisterComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(GalaxyRegisterComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  function fillFormWithValidData() {
+    component.registerForm.setValue({
+      email: 'test@example.com',
+      password: 'password123',
+      password_confirmation: 'password123',
+      public_name: 'testuser'
+    });
+  }
+
+  it('should display success message on successful registration', fakeAsync(() => {
+    fillFormWithValidData();
+
+    component.onSubmit();
+    const tokenReq = httpMock.expectOne("https://aaibackend.test.biocommons.org.au/galaxy/get-registration-token");
+    expect(tokenReq.request.method).toBe('GET');
+    tokenReq.flush({ token: 'mock-token' });
+
+    const registerReq = httpMock.expectOne("https://aaibackend.test.biocommons.org.au/galaxy/register");
+    expect(registerReq.request.method).toBe('POST');
+    registerReq.flush({ success: true });
+
+    tick();
+    fixture.detectChanges();
+
+    const successEl = fixture.debugElement.query(By.css('#register_success_message'));
+    expect(successEl).toBeTruthy();
+    expect(component.registerSuccess).toBeTrue();
+    expect(component.errorMessage).toBeNull();
+  }));
+
+  it('should display error message on failed registration token request', fakeAsync(() => {
+    fillFormWithValidData();
+
+    component.onSubmit();
+    const tokenReq = httpMock.expectOne("https://aaibackend.test.biocommons.org.au/galaxy/get-registration-token");
+    tokenReq.flush("", {status: 500, statusText: "Token request failed"});
+
+    tick();
+    fixture.detectChanges();
+
+    const errorEl = fixture.debugElement.query(By.css('#register_error_message'));
+    expect(errorEl).toBeTruthy();
+    expect(component.registerSuccess).toBeFalse();
+    expect(errorEl.nativeElement.textContent).toContain('Registration failed');
+  }));
+
+  it('should display error message on failed registration POST', fakeAsync(() => {
+    fillFormWithValidData();
+
+    component.onSubmit();
+    const tokenReq = httpMock.expectOne("https://aaibackend.test.biocommons.org.au/galaxy/get-registration-token");
+    tokenReq.flush({ token: 'mock-token' });
+
+    const registerReq = httpMock.expectOne("https://aaibackend.test.biocommons.org.au/galaxy/register");
+    registerReq.flush("", { status: 500, statusText: "Server error" });
+
+    tick();
+    fixture.detectChanges();
+
+    const errorEl = fixture.debugElement.query(By.css('#register_error_message'));
+    expect(errorEl).toBeTruthy();
+    expect(component.registerSuccess).toBeFalse();
+    expect(errorEl.nativeElement.textContent).toContain('Registration failed:');
+  }));
+
+  it('should not submit if form is invalid', () => {
+    component.registerForm.setValue({
+      email: '',
+      password: '',
+      password_confirmation: '',
+      public_name: ''
+    });
+
+    component.onSubmit();
+    fixture.detectChanges();
+
+    expect(component.registerForm.invalid).toBeTrue();
+    expect(component.registerSuccess).toBeFalse(); // Initial state, not set to false
+    expect(component.errorMessage).toBeNull();
   });
 });

--- a/src/app/pages/galaxy/register/galaxy-register.component.ts
+++ b/src/app/pages/galaxy/register/galaxy-register.component.ts
@@ -6,13 +6,12 @@ import {
   FormGroup,
   ReactiveFormsModule,
   ValidationErrors,
-  Validators
+  Validators,
 } from '@angular/forms';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { catchError, of, switchMap } from 'rxjs';
 
-const backendUrl = "https://aaibackend.test.biocommons.org.au";
-
+const backendUrl = 'https://aaibackend.test.biocommons.org.au';
 
 interface GalaxyRegistrationForm {
   email: FormControl<string>;
@@ -29,7 +28,7 @@ interface GalaxyRegistrationToken {
   selector: 'app-register',
   imports: [ReactiveFormsModule],
   templateUrl: './galaxy-register.component.html',
-  styleUrl: './galaxy-register.component.css'
+  styleUrl: './galaxy-register.component.css',
 })
 export class GalaxyRegisterComponent {
   http = inject(HttpClient);
@@ -38,21 +37,41 @@ export class GalaxyRegisterComponent {
   registerSuccess = false;
   errorMessage: string | null = null;
 
-  passwordMatchValidator(group: AbstractControl<GalaxyRegistrationForm>): ValidationErrors | null {
+  passwordMatchValidator(
+    group: AbstractControl<GalaxyRegistrationForm>,
+  ): ValidationErrors | null {
     const password = group.get('password')?.value;
     const confirm = group.get('password_confirmation')?.value;
     return password === confirm ? null : { passwordMismatch: true };
   }
 
   constructor(private formBuilder: FormBuilder) {
-    this.registerForm = formBuilder.group({
-      email: new FormControl('', {nonNullable: true, validators: [Validators.required, Validators.email]}),
-      password: new FormControl('', {nonNullable: true, validators: [Validators.required, Validators.minLength(6)]}),
-      password_confirmation: new FormControl('', {nonNullable: true, validators: [Validators.required, Validators.minLength(6)]}),
-      public_name: new FormControl('', {nonNullable: true, validators: [Validators.required, Validators.minLength(3), Validators.pattern(/^[a-z0-9._-]+$/)]}),
-    }, {validators: [this.passwordMatchValidator]})
+    this.registerForm = formBuilder.group(
+      {
+        email: new FormControl('', {
+          nonNullable: true,
+          validators: [Validators.required, Validators.email],
+        }),
+        password: new FormControl('', {
+          nonNullable: true,
+          validators: [Validators.required, Validators.minLength(6)],
+        }),
+        password_confirmation: new FormControl('', {
+          nonNullable: true,
+          validators: [Validators.required, Validators.minLength(6)],
+        }),
+        public_name: new FormControl('', {
+          nonNullable: true,
+          validators: [
+            Validators.required,
+            Validators.minLength(3),
+            Validators.pattern(/^[a-z0-9._-]+$/),
+          ],
+        }),
+      },
+      { validators: [this.passwordMatchValidator] },
+    );
   }
-
 
   onSubmit() {
     if (this.registerForm.invalid) {
@@ -62,28 +81,35 @@ export class GalaxyRegisterComponent {
 
     const formData = this.registerForm.value;
 
-    this.http.get<GalaxyRegistrationToken>(`${backendUrl}/galaxy/get-registration-token`).pipe(
-      switchMap(response => {
-        const token = response.token;
-        if (!token) throw new Error('No token received');
+    this.http
+      .get<GalaxyRegistrationToken>(
+        `${backendUrl}/galaxy/get-registration-token`,
+      )
+      .pipe(
+        switchMap((response) => {
+          const token = response.token;
+          if (!token) throw new Error('No token received');
 
-        const headers = new HttpHeaders().set('registration-token', token);
-        return this.http.post(`${backendUrl}/galaxy/register`, formData, { headers });
-      }),
-      catchError((error) => {
-        console.error('Registration failed:', error);
-        this.errorMessage = error?.message || 'Registration failed';
-        this.registerSuccess = false;
-        document.getElementById("register_error_message")?.scrollIntoView();
-        return of(null); // return observable to allow subscription to complete
-      })
-    ).subscribe(result => {
-      if (result) {
-        this.registerSuccess = true;
-        this.errorMessage = null;
-        this.registerForm.reset();
-        document.getElementById("register_success_message")?.scrollIntoView();
-      }
-    });
+          const headers = new HttpHeaders().set('registration-token', token);
+          return this.http.post(`${backendUrl}/galaxy/register`, formData, {
+            headers,
+          });
+        }),
+        catchError((error) => {
+          console.error('Registration failed:', error);
+          this.errorMessage = error?.message || 'Registration failed';
+          this.registerSuccess = false;
+          document.getElementById('register_error_message')?.scrollIntoView();
+          return of(null); // return observable to allow subscription to complete
+        }),
+      )
+      .subscribe((result) => {
+        if (result) {
+          this.registerSuccess = true;
+          this.errorMessage = null;
+          this.registerForm.reset();
+          document.getElementById('register_success_message')?.scrollIntoView();
+        }
+      });
   }
 }

--- a/src/app/pages/galaxy/register/galaxy-register.component.ts
+++ b/src/app/pages/galaxy/register/galaxy-register.component.ts
@@ -74,6 +74,7 @@ export class GalaxyRegisterComponent {
         console.error('Registration failed:', error);
         this.errorMessage = error?.message || 'Registration failed';
         this.registerSuccess = false;
+        document.getElementById("register_error_message")?.scrollIntoView();
         return of(null); // return observable to allow subscription to complete
       })
     ).subscribe(result => {


### PR DESCRIPTION
## Description

[AAI-166](https://biocloud.atlassian.net/browse/AAI-166): update the form submission logic so it actually send data to the AAI backend

## Changes

- Submit form registration data to the backend
- Show success/error messages on the form for user feedback

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [ ] I have updated the documentation (if applicable)

## How to Test Manually

Run `ng serve` and visit `localhost:4200/galaxy/register`

## Screenshots for any UI changes

<img width="672" alt="Screenshot 2025-05-19 at 12 00 22 pm" src="https://github.com/user-attachments/assets/23636dc4-b56a-4a76-b8a2-e018d15d2dd1" />



[AAI-166]: https://biocloud.atlassian.net/browse/AAI-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ