### PR TITLE
AAI-162: Add registration complete component and finish BPA registration flow

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -11,6 +11,7 @@ import { GalaxyRegisterComponent } from './pages/galaxy/register/galaxy-register
 import { DefaultLayoutComponent } from './layouts/default-layout/default-layout.component';
 import { GalaxyLayoutComponent } from './layouts/galaxy-layout/galaxy-layout.component';
 import { BpaRegisterComponent } from './pages/bpa/register/bpa-register.component';
+import { RegistrationCompleteComponent } from './pages/bpa/registration-complete/registration-complete.component';
 
 export const routes: Routes = [
   // Standalone route without DefaultLayout
@@ -24,10 +25,13 @@ export const routes: Routes = [
   },
   {
     path: 'bpa',
-    component: BpaRegisterComponent,
     children: [
       { path: '', redirectTo: 'register', pathMatch: 'full' },
       { path: 'register', component: BpaRegisterComponent },
+      {
+        path: 'registration-complete',
+        component: RegistrationCompleteComponent,
+      },
     ],
   },
 

--- a/src/app/pages/bpa/register/bpa-register.component.html
+++ b/src/app/pages/bpa/register/bpa-register.component.html
@@ -1,6 +1,14 @@
 <div class="flex min-h-full flex-col items-center justify-center bg-gray-50">
+  @if (errorNotification()) {
+    <div
+      class="fixed right-12 top-12 z-50 rounded-sm bg-red-600 p-6 text-white shadow-lg"
+    >
+      {{ errorNotification() }}
+    </div>
+  }
+
   <div class="flex w-full items-center justify-center bg-bpa-primary p-12">
-    <a href="https://data.bioplatforms.com/">
+    <a href="https://aaidemo.bioplatforms.com/">
       <img
         src="https://data.bioplatforms.com/BIO-RGB_Full-NEG_Portal_TRANS2_small.webp"
         class="h-20 w-auto"
@@ -146,15 +154,15 @@
           <div class="flex flex-col gap-4" formGroupName="organizations">
             @for (org of organizations; track org.id) {
               <div class="form-group">
-                <div class="controls">
-                  <label class="checkbox" [for]="org.id">
-                    <input
-                      [id]="org.id"
-                      type="checkbox"
-                      [formControlName]="org.id"
-                      [name]="'org-' + org.id"
-                      class="h-4 w-4 rounded-md border-gray-300 bg-gray-100 text-bpa-primary"
-                    />
+                <div class="controls flex items-center gap-2">
+                  <input
+                    [id]="org.id"
+                    type="checkbox"
+                    [formControlName]="org.id"
+                    [name]="'org-' + org.id"
+                    class="h-4 w-4 rounded-md border-gray-300 bg-gray-100 text-bpa-primary"
+                  />
+                  <label class="text-sm font-medium" [for]="org.id">
                     {{ org.name }}
                   </label>
                 </div>
@@ -226,11 +234,11 @@
       </form>
     </div>
   </div>
-  <div class="sticky bottom-0 w-full">
+  <div class="pointer-events-none sticky bottom-0 z-10 w-full">
     <div class="flex w-full justify-end pb-12 pr-12">
       <button
         (click)="scrollToTop()"
-        class="flex h-12 w-12 items-center justify-center rounded-full border border-bpa-primary bg-white text-bpa-primary hover:bg-gray-50"
+        class="pointer-events-auto flex h-12 w-12 items-center justify-center rounded-full border border-bpa-primary bg-white text-bpa-primary hover:bg-gray-50"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/src/app/pages/bpa/registration-complete/registration-complete.component.html
+++ b/src/app/pages/bpa/registration-complete/registration-complete.component.html
@@ -1,0 +1,49 @@
+<div class="flex min-h-full flex-col items-center justify-center bg-gray-50">
+  <div class="flex w-full items-center justify-center bg-bpa-primary p-12">
+    <a href="https://aaidemo.bioplatforms.com/">
+      <img
+        src="https://data.bioplatforms.com/BIO-RGB_Full-NEG_Portal_TRANS2_small.webp"
+        class="h-20 w-auto"
+        alt="Bioplatforms Australia Data Portal Logo"
+      />
+    </a>
+  </div>
+
+  <div
+    class="flex h-full max-w-6xl flex-1 flex-col items-center justify-center gap-24 text-center"
+  >
+    <div class="text-6xl font-semibold">
+      Thank you for registering with the Bioplatforms Australia Data Portal
+    </div>
+    <div class="text-gray-500">
+      Registration successful. Please check your email and verify your email
+      address.
+    </div>
+    <a
+      href="https://aaidemo.bioplatforms.com/"
+      class="rounded-md bg-blue-900 px-4 py-2 text-sm font-medium text-white hover:cursor-pointer hover:bg-blue-950"
+      >Return to BPA Data Portal</a
+    >
+  </div>
+
+  <div
+    class="flex w-full items-center justify-center gap-12 bg-bpa-secondary p-12"
+  >
+    <a href="https://www.bioplatforms.com/">
+      <img
+        src="https://data.bioplatforms.com/BIO-RGB_Large-NEGTRANS_small.webp"
+        alt="Bioplatforms Australia Logo"
+        class="h-20 w-auto"
+      />
+    </a>
+    <a
+      href="https://www.education.gov.au/national-collaborative-research-infrastructure-strategy-ncris"
+    >
+      <img
+        src="https://data.bioplatforms.com/ncris-footer.webp"
+        alt="NCRIS Logo"
+        class="h-20 w-auto"
+      />
+    </a>
+  </div>
+</div>

--- a/src/app/pages/bpa/registration-complete/registration-complete.component.spec.ts
+++ b/src/app/pages/bpa/registration-complete/registration-complete.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RegistrationCompleteComponent } from './registration-complete.component';
+
+describe('RegistrationCompleteComponent', () => {
+  let component: RegistrationCompleteComponent;
+  let fixture: ComponentFixture<RegistrationCompleteComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RegistrationCompleteComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(RegistrationCompleteComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/bpa/registration-complete/registration-complete.component.ts
+++ b/src/app/pages/bpa/registration-complete/registration-complete.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-registration-complete',
+  imports: [],
+  templateUrl: './registration-complete.component.html',
+  styleUrl: './registration-complete.component.css'
+})
+export class RegistrationCompleteComponent {
+
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+html,
+body {
+  scroll-behavior: smooth;
+  height: 100%;
+}


### PR DESCRIPTION
## Description

[AAI-162](https://biocloud.atlassian.net/jira/software/c/projects/AAI/boards/23?assignee=63f30233526117e1514b222b&selectedIssue=AAI-162): Custom BPA-DP new user registration page

## Changes

- Added RegistrationCompleteComponent
- Updated BpaRegisterComponent to handle registration requests and error notifications.
- Added form reset functionality and improved form validation in BpaRegisterComponent.
- Added unit tests for BpaRegisterComponent to cover new features.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

## How to Test Manually

run `npm start` and go to route `/bpa/register` and ` /bpa/registration-complete`

## Screenshots for any UI changes
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/80b4bee6-2404-424a-915b-c6c1b95752d8" />


[AAI-162]: https://biocloud.atlassian.net/browse/AAI-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ