### PR TITLE
Email verification page

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -13,6 +13,7 @@ import { GalaxyLayoutComponent } from './layouts/galaxy-layout/galaxy-layout.com
 import { GalaxyRegisterSuccessComponent } from './pages/galaxy/register-success/galaxy-register-success.component';
 import { BpaRegisterComponent } from './pages/bpa/register/bpa-register.component';
 import { BpaRegistrationSuccessComponent } from './pages/bpa/registration-success/bpa-registration-success.component';
+import { EmailVerifiedComponent } from './pages/user/email-verified/email-verified.component';
 
 export const routes: Routes = [
   // Standalone route without DefaultLayout
@@ -35,6 +36,11 @@ export const routes: Routes = [
         component: BpaRegistrationSuccessComponent,
       },
     ],
+  },
+  {
+    path: 'user', children: [
+      {path: 'email-verified', component: EmailVerifiedComponent}
+    ]
   },
 
   // All other routes use DefaultLayoutComponent

--- a/src/app/pages/user/email-verified/email-verified.component.html
+++ b/src/app/pages/user/email-verified/email-verified.component.html
@@ -1,0 +1,25 @@
+<div class="flex flex-col items-center justify-start min-h-screen bg-gray-50 px-4 py-12">
+  @if (emailVerified) {
+  <div class="flex flex-col gap-8 min-h-64 w-full max-w-lg bg-green-100 border border-green-800 rounded-2xl shadow-md p-8 text-center">
+      <h1 class="text-3xl font-bold text-gray-900 mb-4">Email Verified</h1>
+      <p class="text-gray-700 text-lg mb-6">
+        {{ message }}
+      </p>
+      @if (appUrl)  {
+        <a href="{{ appUrl }}" class="bg-galaxy-primary text-white p-4 rounded-md">
+          Go to {{ applicationName }}
+        </a>
+      }
+  </div>
+  } @else {
+  <div class="flex flex-col gap-8 min-h-64 w-full max-w-lg bg-red-100 border border-red-800 rounded-2xl shadow-md p-8 text-center">
+      <h1 class="text-3xl font-bold text-gray-900 mb-4">Email verification error</h1>
+      <p class="text-gray-700 text-lg mb-6">
+        Your email could not be verified. Please try again.<br/><br/>
+
+        @if (errorMessage) {
+          <strong>Error details:</strong> {{ errorMessage  }}
+        }
+      </p>
+  </div>
+}

--- a/src/app/pages/user/email-verified/email-verified.component.spec.ts
+++ b/src/app/pages/user/email-verified/email-verified.component.spec.ts
@@ -1,0 +1,135 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { EmailVerifiedComponent } from './email-verified.component';
+import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
+
+describe('EmailVerifiedComponent', () => {
+  let component: EmailVerifiedComponent;
+  let fixture: ComponentFixture<EmailVerifiedComponent>;
+
+  const createComponentWithParams = (queryParams: Record<string, string | null>) => {
+    TestBed.configureTestingModule({
+      imports: [EmailVerifiedComponent],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            queryParamMap: of({
+              get: (key: string) => queryParams[key] ?? null
+            })
+          }
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EmailVerifiedComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  };
+
+  // 🔍 Successful verification test
+  it('should display success message for verified email with known app', () => {
+    createComponentWithParams({
+      success: 'true',
+      application_name: 'Galaxy Test Portal'
+    });
+
+    expect(component.emailVerified).toBeTrue();
+    expect(component.applicationName).toBe('Galaxy Test Portal');
+    expect(component.appId).toBe('galaxy');
+    expect(component.appUrl).toBe('https://galaxy.test.biocommons.org.au');
+    expect(component.message).toContain('Your email has been successfully verified for Galaxy Test Portal');
+    expect(component.errorMessage).toBe('');
+  });
+
+  // ❌ Unsuccessful verification test
+  it('should handle verification failure and show error message', () => {
+    createComponentWithParams({
+      success: 'false',
+      application_name: 'BPA Demo',
+      message: 'Invalid verification token'
+    });
+
+    expect(component.emailVerified).toBeFalse();
+    expect(component.appId).toBe('bpa');
+    expect(component.appUrl).toBe('https://aaidemo.bioplatforms.com');
+    expect(component.message).toBe('');
+    expect(component.errorMessage).toBe('Invalid verification token');
+  });
+
+  // 🧪 Fallback behavior when no application_name is provided
+  it('should handle verified email with no application name', () => {
+    createComponentWithParams({
+      success: 'true'
+    });
+
+    expect(component.emailVerified).toBeTrue();
+    expect(component.applicationName).toBeNull();
+    expect(component.appId).toBeNull();
+    expect(component.appUrl).toBeNull();
+    expect(component.message).toBe('Your email has been successfully verified. You can now log in.');
+  });
+
+  // ❓ Edge case: unknown application name
+  it('should not match unknown application name to an appId', () => {
+    createComponentWithParams({
+      success: 'true',
+      application_name: 'UnknownApp'
+    });
+
+    expect(component.appId).toBeNull();
+    expect(component.appUrl).toBeNull();
+    expect(component.message).toContain('Your email has been successfully verified for UnknownApp');
+  });
+
+  // ✅ DOM: Successful verification test
+  it('should render success message and app link for known app', () => {
+    createComponentWithParams({
+      success: 'true',
+      application_name: 'Galaxy'
+    });
+
+    const compiled = fixture.nativeElement as HTMLElement;
+
+    const heading = compiled.querySelector('h1');
+    const paragraph = compiled.querySelector('p');
+    const link = compiled.querySelector('a');
+
+    expect(heading?.textContent).toContain('Email Verified');
+    expect(paragraph?.textContent).toContain('Your email has been successfully verified for Galaxy');
+    expect(link?.textContent).toContain('Go to Galaxy');
+    expect(link?.getAttribute('href')).toBe('https://galaxy.test.biocommons.org.au');
+  });
+
+  // ❌ DOM: Unsuccessful verification
+  it('should render error message and error detail if verification failed', () => {
+    createComponentWithParams({
+      success: 'false',
+      application_name: 'bpa',
+      message: 'Verification token expired'
+    });
+
+    const compiled = fixture.nativeElement as HTMLElement;
+
+    const heading = compiled.querySelector('h1');
+    const paragraph = compiled.querySelector('p');
+
+    expect(heading?.textContent).toContain('Email verification error');
+    expect(paragraph?.textContent).toContain('Your email could not be verified');
+    expect(paragraph?.textContent).toContain('Verification token expired');
+  });
+
+  // ❓ DOM: Unknown application name should not render app link
+  it('should show message but not link for unknown app', () => {
+    createComponentWithParams({
+      success: 'true',
+      application_name: 'RandomApp'
+    });
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const link = compiled.querySelector('a');
+
+    expect(compiled.querySelector('p')?.textContent).toContain('RandomApp');
+    expect(link).toBeNull();
+  });
+});

--- a/src/app/pages/user/email-verified/email-verified.component.ts
+++ b/src/app/pages/user/email-verified/email-verified.component.ts
@@ -1,0 +1,59 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+type AppId = 'bpa' | 'galaxy';
+
+@Component({
+  selector: 'app-email-verified',
+  templateUrl: './email-verified.component.html',
+  styleUrls: ['./email-verified.component.css']
+})
+export class EmailVerifiedComponent implements OnInit {
+  applicationName: string | null = null;
+  appId: AppId | null = null;
+  appUrl: string | null = null;
+  emailVerified = false;
+  message = '';
+  errorMessage = '';
+
+
+  app_urls: Record<AppId, string> = {
+    'bpa': 'https://aaidemo.bioplatforms.com',
+    'galaxy': 'https://galaxy.test.biocommons.org.au'
+  };
+
+  constructor(private route: ActivatedRoute) {}
+
+  ngOnInit(): void {
+    this.route.queryParamMap.subscribe(params => {
+      this.applicationName = params.get('application_name');
+      this.setAppIds();
+      if (this.appId) {
+        this.appUrl = this.app_urls[this.appId];
+      }
+      // You may not get email_verified directly unless you're handling it yourself
+      // In that case, consider this page is ONLY reached after success
+      this.emailVerified = params.get('success') === 'true'; // Considered verified if redirected here
+      this.errorMessage = params.get('message') || '';
+      this.setMessage();
+    });
+  }
+
+  // Try to set app ID from application name - not 100% robust but allows us to
+  // show more info for known apps
+  private setAppIds(): void {
+    if (this.applicationName?.toLowerCase().includes('bpa')) {
+      this.appId = 'bpa';
+    } else if (this.applicationName?.toLowerCase().includes('galaxy')) {
+      this.appId = 'galaxy';
+    }
+  }
+
+  private setMessage(): void {
+    if (this.emailVerified) {
+      this.message = this.applicationName
+        ? `Your email has been successfully verified for ${this.applicationName}. You can now log in.`
+        : `Your email has been successfully verified. You can now log in.`;
+    }
+  }
+}


### PR DESCRIPTION
## Description

[AAI-217](https://biocloud.atlassian.net/browse/AAI-217): Need a page for users to be redirected to after verifying their email. We should be able to do this with app-specific pages by including the app name in the callback from Auth0

## Changes

- "Email verified" page that shows success/error message for verification
- Include app name/link to app homepage, based on parsing the application name (not 100% robust but should work for now)
- Unit tests for the component

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

## How to Test Manually

Run `ng serve` and visit `http://localhost:4200/user/email-verified?message=Failed` to see the error page, `http://localhost:4200/user/email-verified?success=true&application_name=BPA` to see a successful verification for BPA

## Screenshots for any UI changes

<img width="656" alt="Screenshot 2025-05-22 at 9 54 32 am" src="https://github.com/user-attachments/assets/b5c5b733-01a8-4268-8bf6-5015cb9b372a" />

<img width="650" alt="Screenshot 2025-05-22 at 9 56 02 am" src="https://github.com/user-attachments/assets/7a8df19b-64f1-4389-b0b7-2a807bcc2344" />


[AAI-217]: https://biocloud.atlassian.net/browse/AAI-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ