### PR TITLE
AAI-217 Simplify email verification

### DIFF
--- a/src/app/pages/user/email-verified/email-verified.component.html
+++ b/src/app/pages/user/email-verified/email-verified.component.html
@@ -3,13 +3,14 @@
   <div class="flex flex-col gap-8 min-h-64 w-full max-w-lg bg-green-100 border border-green-800 rounded-2xl shadow-md p-8 text-center">
       <h1 class="text-3xl font-bold text-gray-900 mb-4">Email Verified</h1>
       <p class="text-gray-700 text-lg mb-6">
-        {{ message }}
+        Your email has been successfully verified. You can now log in.
       </p>
-      @if (appUrl)  {
-        <a href="{{ appUrl }}" class="bg-galaxy-primary text-white p-4 rounded-md">
-          Go to {{ applicationName }}
-        </a>
-      }
+      <a href="{{ app_urls['galaxy']}}" class="bg-blue-900 text-white p-4 rounded-md">
+        Go to Galaxy Australia
+      </a>
+      <a href="{{ app_urls['bpa']}}" class="bg-blue-900 text-white p-4 rounded-md">
+        Go to BioPlatforms Australia Data Portal
+      </a>
   </div>
   } @else {
   <div class="flex flex-col gap-8 min-h-64 w-full max-w-lg bg-red-100 border border-red-800 rounded-2xl shadow-md p-8 text-center">

--- a/src/app/pages/user/email-verified/email-verified.component.ts
+++ b/src/app/pages/user/email-verified/email-verified.component.ts
@@ -9,13 +9,8 @@ type AppId = 'bpa' | 'galaxy';
   styleUrls: ['./email-verified.component.css']
 })
 export class EmailVerifiedComponent implements OnInit {
-  applicationName: string | null = null;
-  appId: AppId | null = null;
-  appUrl: string | null = null;
   emailVerified = false;
-  message = '';
   errorMessage = '';
-
 
   app_urls: Record<AppId, string> = {
     'bpa': 'https://aaidemo.bioplatforms.com',
@@ -26,34 +21,11 @@ export class EmailVerifiedComponent implements OnInit {
 
   ngOnInit(): void {
     this.route.queryParamMap.subscribe(params => {
-      this.applicationName = params.get('application_name');
-      this.setAppIds();
-      if (this.appId) {
-        this.appUrl = this.app_urls[this.appId];
-      }
       // You may not get email_verified directly unless you're handling it yourself
       // In that case, consider this page is ONLY reached after success
       this.emailVerified = params.get('success') === 'true'; // Considered verified if redirected here
       this.errorMessage = params.get('message') || '';
-      this.setMessage();
     });
   }
 
-  // Try to set app ID from application name - not 100% robust but allows us to
-  // show more info for known apps
-  private setAppIds(): void {
-    if (this.applicationName?.toLowerCase().includes('bpa')) {
-      this.appId = 'bpa';
-    } else if (this.applicationName?.toLowerCase().includes('galaxy')) {
-      this.appId = 'galaxy';
-    }
-  }
-
-  private setMessage(): void {
-    if (this.emailVerified) {
-      this.message = this.applicationName
-        ? `Your email has been successfully verified for ${this.applicationName}. You can now log in.`
-        : `Your email has been successfully verified. You can now log in.`;
-    }
-  }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>AAI Portal</title>
+    <title>Accounts | Australian BioCommons</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link


### PR DESCRIPTION
## Description

[AAI-217](https://biocloud.atlassian.net/browse/AAI-217): Because we do our registration via the AAI Portal/AAI Backend, we end up with AAI Backend as the application_name for both Galaxy and BPA. This makes it hard to do app-specific pages. For now (coming up to the demo) I think we are best off with a general email verification page.

Possible future fixes 

## Changes

- Remove app logic from email verification page
- Just show BPA and Galaxy links on the generic verification page

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit / integration tests that prove my fix is effective or that my feature works
- [ ] I have run all tests locally and they pass
- [ ] I have updated the documentation (if applicable)

## How to Test Manually

Run `ng serve` and visit http://localhost:4200/user/email-verified?success=true

## Screenshots for any UI changes

![Screenshot 2025-05-23 at 2 12 42 pm](https://github.com/user-attachments/assets/1b802318-c865-41d8-8448-96717a471ae4)

