### PR TITLE
AAI-223 update email verification page to show platform-specific login link

### DIFF
--- a/src/app/pages/user/email-verified/email-verified.component.html
+++ b/src/app/pages/user/email-verified/email-verified.component.html
@@ -27,11 +27,8 @@
       <div
         class="flex flex-1 flex-col gap-6 *:rounded-md *:bg-blue-800 *:px-6 *:py-3 *:text-white"
       >
-        <a class="hover:bg-blue-900" [href]="appUrls.galaxy">
-          Go to Galaxy Australia
-        </a>
-        <a class="hover:bg-blue-900" [href]="appUrls.bpa">
-          Go to Bioplatforms Australia Data Portal
+        <a class="hover:bg-blue-900" [href]="appUrl()">
+          Continue
         </a>
       </div>
     } @else {

--- a/src/app/pages/user/email-verified/email-verified.component.ts
+++ b/src/app/pages/user/email-verified/email-verified.component.ts
@@ -2,8 +2,15 @@ import { Component, computed, signal, inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Title } from '@angular/platform-browser';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../../../environments/environment';
 
-type AppId = 'bpa' | 'galaxy';
+type AppId = 'bpa' | 'galaxy' | 'biocommons';
+
+interface UserInfoResponse {
+  app: AppId;
+  // Add any other expected fields if needed
+}
 
 @Component({
   selector: 'app-email-verified',
@@ -14,28 +21,49 @@ type AppId = 'bpa' | 'galaxy';
 export class EmailVerifiedComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly titleService = inject(Title);
+  private readonly http = inject(HttpClient);
+
+  readonly appUrls: Record<AppId, string> = {
+    bpa: 'https://aaidemo.bioplatforms.com',
+    galaxy: 'https://galaxy.test.biocommons.org.au',
+    biocommons: 'https://login.test.biocommons.org.au',
+  } as const;
 
   readonly emailVerified = signal(false);
+  readonly userEmail = signal('');
   readonly errorMessage = signal('');
+  readonly appId = signal<AppId>('biocommons');
+  readonly appUrl = signal(this.appUrls['biocommons']);
 
   private readonly title = computed(() => {
     const status = this.emailVerified() ? 'Successful' : 'Failed';
     return `Email Verification | ${status}`;
   });
 
-  readonly appUrls: Record<AppId, string> = {
-    bpa: 'https://aaidemo.bioplatforms.com',
-    galaxy: 'https://galaxy.test.biocommons.org.au',
-  } as const;
-
   constructor() {
     this.titleService.setTitle('Email Verification');
     this.route.queryParamMap.pipe(takeUntilDestroyed()).subscribe((params) => {
-      // You may not get email_verified directly unless you're handling it yourself
-      // In that case, consider this page is ONLY reached after success
-      this.emailVerified.set(params.get('success') === 'true'); // Considered verified if redirected here
+      this.emailVerified.set(params.get('success') === 'true');
       this.errorMessage.set(params.get('message') || '');
+      this.userEmail.set(params.get('email') || '');
       this.titleService.setTitle(this.title());
+
+      if (this.userEmail()) {
+        this.getAppInfo(this.userEmail());
+      }
     });
+  }
+
+  getAppInfo(email: string): void {
+    this.http.get<UserInfoResponse>(`${environment.auth0.backend}/registration_info?user_email=${encodeURIComponent(email)}`)
+      .subscribe({
+        next: (data) => {
+          this.appId.set(data.app);
+          this.appUrl.set(this.appUrls[this.appId()])
+        },
+        error: (err) => {
+          console.error(`Failed to fetch app info: ${err}`);
+        }
+      });
   }
 }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -6,5 +6,6 @@ export const environment = {
     redirectUri: window.location.origin,
     audience: 'https://dev-bc.au.auth0.com/api/v2/',
     scope: 'read:current_user update:current_user_metadata',
+    backend: 'https://aaibackend.test.biocommons.org.au'
   },
 };


### PR DESCRIPTION
## Description

[AAI-223](https://biocloud.atlassian.net/browse/AAI-223): add platform-specific links back in to the email verification page. To do this:

* We pass the user's email as a query parameter from Auth0, after they click the verifcation link
* We use the email to do a request to the `aai-backend`'s `registration_info` endpoint, which tells us which app they signed up for (based on `app_metadata`).
* We update the login link based on the response.

We default to the default biocommons login when the app isn't available for any reason.

## Changes

- Look up app used to register from the backend
- Update login link based on app
- Unit tests

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit / integration tests that prove my fix is effective or that my feature works
- [ ] I have run all tests locally and they pass
- [ ] I have updated the documentation (if applicable)

## How to Test Manually

Run `ng test`

## Screenshots for any UI changes

Note we just use "Continue" as the button text for all apps - users already know which app they're verifying for/continuing to

![Screenshot 2025-06-11 at 2 23 31 pm](https://github.com/user-attachments/assets/3fbcc9f1-d343-44e2-8d1a-33e6fee732e3)
