### PR TITLE
AAI-255: Admin token validation for AAI portal admin page & route guards

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -16,8 +16,19 @@ import { BpaRegistrationSuccessComponent } from './pages/bpa/registration-succes
 import { EmailVerifiedComponent } from './pages/user/email-verified/email-verified.component';
 import { BpaRegisterSelectionComponent } from './pages/bpa/register-selection/bpa-register-selection.component';
 import { GalaxyRegisterSelectionComponent } from './pages/galaxy/register-selection/galaxy-register-selection.component';
+import { LoginComponent } from './pages/login/login.component';
+import { loginGuard } from './core/guards/login.guard';
+import { authGuard } from './core/guards/auth.guard';
+import { adminGuard } from './core/guards/admin.guard';
+import { userGuard } from './core/guards/user.guard';
 
 export const routes: Routes = [
+  // Login route - only accessible when not logged in
+  {
+    path: 'login',
+    component: LoginComponent,
+    canActivate: [loginGuard],
+  },
   // Standalone route without DefaultLayout
   {
     path: 'galaxy',
@@ -50,11 +61,12 @@ export const routes: Routes = [
   {
     path: '',
     component: DefaultLayoutComponent,
+    canActivate: [authGuard],
     children: [
-      { path: '', redirectTo: 'services', pathMatch: 'full' },
       {
         path: 'services',
         component: ServicesComponent,
+        canActivate: [userGuard],
         children: [
           {
             path: 'request',
@@ -62,11 +74,11 @@ export const routes: Routes = [
           },
         ],
       },
-      { path: 'access', component: AccessComponent },
-      { path: 'pending', component: PendingComponent },
-      { path: 'all-users', component: ListUsersComponent },
-      { path: 'revoked', component: RevokedComponent },
-      { path: 'requests', component: RequestsComponent },
+      { path: 'access', component: AccessComponent, canActivate: [userGuard] },
+      { path: 'pending', component: PendingComponent, canActivate: [userGuard] },
+      { path: 'all-users', component: ListUsersComponent, canActivate: [adminGuard] },
+      { path: 'revoked', component: RevokedComponent, canActivate: [adminGuard] },
+      { path: 'requests', component: RequestsComponent, canActivate: [adminGuard] },
     ],
   },
   { path: '**', component: NotFoundComponent },

--- a/src/app/core/guards/admin.guard.spec.ts
+++ b/src/app/core/guards/admin.guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { adminGuard } from './admin.guard';
+
+describe('adminGuard', () => {
+  const executeGuard: CanActivateFn = (...guardParameters) => 
+      TestBed.runInInjectionContext(() => adminGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/src/app/core/guards/admin.guard.ts
+++ b/src/app/core/guards/admin.guard.ts
@@ -1,0 +1,32 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+import { AuthService as Auth0Service } from '@auth0/auth0-angular';
+import { map, take, filter, switchMap } from 'rxjs/operators';
+
+export const adminGuard: CanActivateFn = () => {
+  const authService = inject(AuthService);
+  const auth0Service = inject(Auth0Service);
+  const router = inject(Router);
+
+  return auth0Service.isLoading$.pipe(
+    filter(isLoading => !isLoading),
+    switchMap(() => auth0Service.isAuthenticated$),
+    take(1),
+    switchMap(isAuthenticated => {
+      if (isAuthenticated) {
+        return authService.isAdmin().pipe(
+          map(isAdmin => {
+            if (isAdmin) {
+              return true;
+            } else {
+              router.navigate(['/']);
+              return false;
+            }
+          })
+        );
+      }
+      return [false];
+    })
+  );
+};

--- a/src/app/core/guards/admin.guard.ts
+++ b/src/app/core/guards/admin.guard.ts
@@ -1,32 +1,26 @@
 import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
 import { AuthService } from '../services/auth.service';
-import { AuthService as Auth0Service } from '@auth0/auth0-angular';
-import { map, take, filter, switchMap } from 'rxjs/operators';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { filter, map, take } from 'rxjs/operators';
 
 export const adminGuard: CanActivateFn = () => {
   const authService = inject(AuthService);
-  const auth0Service = inject(Auth0Service);
   const router = inject(Router);
 
-  return auth0Service.isLoading$.pipe(
+  return toObservable(authService.isLoading).pipe(
     filter(isLoading => !isLoading),
-    switchMap(() => auth0Service.isAuthenticated$),
     take(1),
-    switchMap(isAuthenticated => {
-      if (isAuthenticated) {
-        return authService.isAdmin().pipe(
-          map(isAdmin => {
-            if (isAdmin) {
-              return true;
-            } else {
-              router.navigate(['/']);
-              return false;
-            }
-          })
-        );
+    map(() => {
+      const isAuthenticated = authService.isAuthenticated();
+      const isAdmin = authService.isAdmin();
+      
+      if (isAuthenticated && isAdmin) {
+        return true;
+      } else {
+        router.navigate(['/']);
+        return false;
       }
-      return [false];
     })
   );
 };

--- a/src/app/core/guards/auth.guard.spec.ts
+++ b/src/app/core/guards/auth.guard.spec.ts
@@ -1,54 +1,67 @@
 import { TestBed } from '@angular/core/testing';
-import { Router, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import {
+  Router,
+  ActivatedRouteSnapshot,
+  RouterStateSnapshot,
+} from '@angular/router';
 import { authGuard } from './auth.guard';
 import { AuthService } from '../services/auth.service';
 import { signal } from '@angular/core';
+import { Observable } from 'rxjs';
 
 describe('authGuard', () => {
   let mockAuthService: jasmine.SpyObj<AuthService>;
   let mockRouter: jasmine.SpyObj<Router>;
 
   beforeEach(() => {
-    const authSpy = jasmine.createSpyObj('AuthService', [], {
-      isAuthenticated: signal(false)
+    const authSpy = jasmine.createSpyObj('AuthService', ['isAuthenticated'], {
+      isLoading: signal(false),
     });
     const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
 
     TestBed.configureTestingModule({
       providers: [
         { provide: AuthService, useValue: authSpy },
-        { provide: Router, useValue: routerSpy }
-      ]
+        { provide: Router, useValue: routerSpy },
+      ],
     });
 
-    mockAuthService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
+    mockAuthService = TestBed.inject(
+      AuthService,
+    ) as jasmine.SpyObj<AuthService>;
     mockRouter = TestBed.inject(Router) as jasmine.SpyObj<Router>;
-  });
-
-  it('should return true when user is authenticated', () => {
-    mockAuthService.isAuthenticated.set(true);
-
-    const result = TestBed.runInInjectionContext(() => 
-      authGuard({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot)
-    );
-
-    expect(result).toBe(true);
-    expect(mockRouter.navigate).not.toHaveBeenCalled();
-  });
-
-  it('should return false and navigate to root when user is not authenticated', () => {
-    mockAuthService.isAuthenticated.set(false);
-
-    const result = TestBed.runInInjectionContext(() => 
-      authGuard({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot)
-    );
-
-    expect(result).toBe(false);
-    expect(mockRouter.navigate).toHaveBeenCalledWith(['']);
   });
 
   it('should be created', () => {
     const executeGuard = TestBed.runInInjectionContext(() => authGuard);
     expect(executeGuard).toBeTruthy();
+  });
+
+  it('should return true when user is authenticated', (done) => {
+    mockAuthService.isAuthenticated.and.returnValue(true);
+
+    const result = TestBed.runInInjectionContext(() =>
+      authGuard({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+    );
+
+    (result as Observable<boolean>).subscribe((value) => {
+      expect(value).toBe(true);
+      expect(mockRouter.navigate).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('should return false and navigate to login when user is not authenticated', (done) => {
+    mockAuthService.isAuthenticated.and.returnValue(false);
+
+    const result = TestBed.runInInjectionContext(() =>
+      authGuard({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+    );
+
+    (result as Observable<boolean>).subscribe((value) => {
+      expect(value).toBe(false);
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/login']);
+      done();
+    });
   });
 });

--- a/src/app/core/guards/auth.guard.ts
+++ b/src/app/core/guards/auth.guard.ts
@@ -3,13 +3,13 @@ import { CanActivateFn, Router } from '@angular/router';
 import { AuthService } from '../../core/services/auth.service';
 
 export const authGuard: CanActivateFn = () => {
-  const auth = inject(AuthService);
+  const authService = inject(AuthService);
   const router = inject(Router);
 
-  if (auth.isAuthenticated()) {
+  if (authService.isAuthenticated()) {
     return true;
   } else {
-    router.navigate(['']);
+    router.navigate(['/login']);
     return false;
   }
 };

--- a/src/app/core/guards/auth.guard.ts
+++ b/src/app/core/guards/auth.guard.ts
@@ -1,15 +1,23 @@
 import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
-import { AuthService } from '../../core/services/auth.service';
+import { AuthService } from '../services/auth.service';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { filter, map, take } from 'rxjs/operators';
 
 export const authGuard: CanActivateFn = () => {
   const authService = inject(AuthService);
   const router = inject(Router);
 
-  if (authService.isAuthenticated()) {
-    return true;
-  } else {
-    router.navigate(['/login']);
-    return false;
-  }
+  return toObservable(authService.isLoading).pipe(
+    filter(isLoading => !isLoading),
+    take(1),
+    map(() => {
+      if (authService.isAuthenticated()) {
+        return true;
+      } else {
+        router.navigate(['/login']);
+        return false;
+      }
+    })
+  );
 };

--- a/src/app/core/guards/login.guard.spec.ts
+++ b/src/app/core/guards/login.guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { loginGuard } from './login.guard';
+
+describe('loginGuard', () => {
+  const executeGuard: CanActivateFn = (...guardParameters) => 
+      TestBed.runInInjectionContext(() => loginGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/src/app/core/guards/login.guard.spec.ts
+++ b/src/app/core/guards/login.guard.spec.ts
@@ -1,17 +1,65 @@
 import { TestBed } from '@angular/core/testing';
-import { CanActivateFn } from '@angular/router';
-
+import {
+  Router,
+  ActivatedRouteSnapshot,
+  RouterStateSnapshot,
+} from '@angular/router';
 import { loginGuard } from './login.guard';
+import { AuthService } from '../services/auth.service';
+import { signal } from '@angular/core';
+import { Observable } from 'rxjs';
 
 describe('loginGuard', () => {
-  const executeGuard: CanActivateFn = (...guardParameters) => 
-      TestBed.runInInjectionContext(() => loginGuard(...guardParameters));
+  let mockAuthService: jasmine.SpyObj<AuthService>;
+  let mockRouter: jasmine.SpyObj<Router>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    const authSpy = jasmine.createSpyObj('AuthService', ['isAuthenticated'], {
+      isLoading: signal(false),
+    });
+    const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AuthService, useValue: authSpy },
+        { provide: Router, useValue: routerSpy },
+      ],
+    });
+
+    mockAuthService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
+    mockRouter = TestBed.inject(Router) as jasmine.SpyObj<Router>;
   });
 
   it('should be created', () => {
+    const executeGuard = TestBed.runInInjectionContext(() => loginGuard);
     expect(executeGuard).toBeTruthy();
+  });
+
+  it('should return true when user is not authenticated', (done) => {
+    mockAuthService.isAuthenticated.and.returnValue(false);
+
+    const result = TestBed.runInInjectionContext(() =>
+      loginGuard({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+    );
+
+    (result as Observable<boolean>).subscribe((value) => {
+      expect(value).toBe(true);
+      expect(mockRouter.navigate).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('should return false and navigate to home when user is authenticated', (done) => {
+    mockAuthService.isAuthenticated.and.returnValue(true);
+
+    const result = TestBed.runInInjectionContext(() =>
+      loginGuard({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+    );
+
+    (result as Observable<boolean>).subscribe((value) => {
+      expect(value).toBe(false);
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/']);
+      done();
+    });
   });
 });

--- a/src/app/core/guards/login.guard.ts
+++ b/src/app/core/guards/login.guard.ts
@@ -1,17 +1,19 @@
 import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
-import { AuthService as Auth0Service } from '@auth0/auth0-angular';
-import { map, take, filter, switchMap } from 'rxjs/operators';
+import { AuthService } from '../services/auth.service';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { filter, map, take } from 'rxjs/operators';
 
 export const loginGuard: CanActivateFn = () => {
-  const auth0Service = inject(Auth0Service);
+  const authService = inject(AuthService);
   const router = inject(Router);
 
-  return auth0Service.isLoading$.pipe(
+  return toObservable(authService.isLoading).pipe(
     filter(isLoading => !isLoading),
-    switchMap(() => auth0Service.isAuthenticated$),
     take(1),
-    map(isAuthenticated => {
+    map(() => {
+      const isAuthenticated = authService.isAuthenticated();
+      
       if (isAuthenticated) {
         router.navigate(['/']);
         return false;

--- a/src/app/core/guards/login.guard.ts
+++ b/src/app/core/guards/login.guard.ts
@@ -1,0 +1,23 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService as Auth0Service } from '@auth0/auth0-angular';
+import { map, take, filter, switchMap } from 'rxjs/operators';
+
+export const loginGuard: CanActivateFn = () => {
+  const auth0Service = inject(Auth0Service);
+  const router = inject(Router);
+
+  return auth0Service.isLoading$.pipe(
+    filter(isLoading => !isLoading),
+    switchMap(() => auth0Service.isAuthenticated$),
+    take(1),
+    map(isAuthenticated => {
+      if (isAuthenticated) {
+        router.navigate(['/']);
+        return false;
+      } else {
+        return true;
+      }
+    })
+  );
+};

--- a/src/app/core/guards/user.guard.spec.ts
+++ b/src/app/core/guards/user.guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { userGuard } from './user.guard';
+
+describe('userGuard', () => {
+  const executeGuard: CanActivateFn = (...guardParameters) => 
+      TestBed.runInInjectionContext(() => userGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/src/app/core/guards/user.guard.spec.ts
+++ b/src/app/core/guards/user.guard.spec.ts
@@ -1,17 +1,82 @@
 import { TestBed } from '@angular/core/testing';
-import { CanActivateFn } from '@angular/router';
-
+import {
+  Router,
+  ActivatedRouteSnapshot,
+  RouterStateSnapshot,
+} from '@angular/router';
 import { userGuard } from './user.guard';
+import { AuthService } from '../services/auth.service';
+import { signal } from '@angular/core';
+import { Observable } from 'rxjs';
 
 describe('userGuard', () => {
-  const executeGuard: CanActivateFn = (...guardParameters) => 
-      TestBed.runInInjectionContext(() => userGuard(...guardParameters));
+  let mockAuthService: jasmine.SpyObj<AuthService>;
+  let mockRouter: jasmine.SpyObj<Router>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    const authSpy = jasmine.createSpyObj('AuthService', ['isAuthenticated', 'isAdmin'], {
+      isLoading: signal(false),
+    });
+    const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AuthService, useValue: authSpy },
+        { provide: Router, useValue: routerSpy },
+      ],
+    });
+
+    mockAuthService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
+    mockRouter = TestBed.inject(Router) as jasmine.SpyObj<Router>;
   });
 
   it('should be created', () => {
+    const executeGuard = TestBed.runInInjectionContext(() => userGuard);
     expect(executeGuard).toBeTruthy();
+  });
+
+  it('should return true when user is authenticated and not admin', (done) => {
+    mockAuthService.isAuthenticated.and.returnValue(true);
+    mockAuthService.isAdmin.and.returnValue(false);
+
+    const result = TestBed.runInInjectionContext(() =>
+      userGuard({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+    );
+
+    (result as Observable<boolean>).subscribe((value) => {
+      expect(value).toBe(true);
+      expect(mockRouter.navigate).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('should return false and navigate to home when user is admin', (done) => {
+    mockAuthService.isAuthenticated.and.returnValue(true);
+    mockAuthService.isAdmin.and.returnValue(true);
+
+    const result = TestBed.runInInjectionContext(() =>
+      userGuard({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+    );
+
+    (result as Observable<boolean>).subscribe((value) => {
+      expect(value).toBe(false);
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/']);
+      done();
+    });
+  });
+
+  it('should return false and navigate to home when user is not authenticated', (done) => {
+    mockAuthService.isAuthenticated.and.returnValue(false);
+    mockAuthService.isAdmin.and.returnValue(false);
+
+    const result = TestBed.runInInjectionContext(() =>
+      userGuard({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+    );
+
+    (result as Observable<boolean>).subscribe((value) => {
+      expect(value).toBe(false);
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/']);
+      done();
+    });
   });
 });

--- a/src/app/core/guards/user.guard.ts
+++ b/src/app/core/guards/user.guard.ts
@@ -1,0 +1,32 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+import { AuthService as Auth0Service } from '@auth0/auth0-angular';
+import { map, take, filter, switchMap } from 'rxjs/operators';
+
+export const userGuard: CanActivateFn = () => {
+  const authService = inject(AuthService);
+  const auth0Service = inject(Auth0Service);
+  const router = inject(Router);
+
+  return auth0Service.isLoading$.pipe(
+    filter(isLoading => !isLoading),
+    switchMap(() => auth0Service.isAuthenticated$),
+    take(1),
+    switchMap(isAuthenticated => {
+      if (isAuthenticated) {
+        return authService.isAdmin().pipe(
+          map(isAdmin => {
+            if (!isAdmin) {
+              return true;
+            } else {
+              router.navigate(['/']);
+              return false;
+            }
+          })
+        );
+      }
+      return [false];
+    })
+  );
+};

--- a/src/app/core/guards/user.guard.ts
+++ b/src/app/core/guards/user.guard.ts
@@ -1,32 +1,26 @@
 import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
 import { AuthService } from '../services/auth.service';
-import { AuthService as Auth0Service } from '@auth0/auth0-angular';
-import { map, take, filter, switchMap } from 'rxjs/operators';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { filter, map, take } from 'rxjs/operators';
 
 export const userGuard: CanActivateFn = () => {
   const authService = inject(AuthService);
-  const auth0Service = inject(Auth0Service);
   const router = inject(Router);
 
-  return auth0Service.isLoading$.pipe(
+  return toObservable(authService.isLoading).pipe(
     filter(isLoading => !isLoading),
-    switchMap(() => auth0Service.isAuthenticated$),
     take(1),
-    switchMap(isAuthenticated => {
-      if (isAuthenticated) {
-        return authService.isAdmin().pipe(
-          map(isAdmin => {
-            if (!isAdmin) {
-              return true;
-            } else {
-              router.navigate(['/']);
-              return false;
-            }
-          })
-        );
+    map(() => {
+      const isAuthenticated = authService.isAuthenticated();
+      const isAdmin = authService.isAdmin();
+      
+      if (isAuthenticated && !isAdmin) {
+        return true;
+      } else {
+        router.navigate(['/']);
+        return false;
       }
-      return [false];
     })
   );
 };

--- a/src/app/core/interceptors/auth.interceptor.ts
+++ b/src/app/core/interceptors/auth.interceptor.ts
@@ -9,14 +9,14 @@ import { environment } from '../../../environments/environment';
  * HTTP interceptor that adds the Auth0 access token to requests sent to the AAI backend API
  */
 export const authInterceptor: HttpInterceptorFn = (req, next) => {
-  const auth0 = inject(Auth0Service);
+  const auth0Service = inject(Auth0Service);
 
   const isBackendRequest = req.url.includes(environment.auth0.backend);
   const isRegistrationEndpoint = req.url.includes('/register');
 
   // For requests to the AAI backend that's not a registration endpoint
   if (isBackendRequest && !isRegistrationEndpoint) {
-    return auth0.getAccessTokenSilently().pipe(
+    return auth0Service.getAccessTokenSilently().pipe(
       switchMap((token) => {
         // Add Bearer token to request headers
         const authReq = req.clone({

--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -86,10 +86,10 @@ describe('AuthService', () => {
 
     mockAuth0Service.getAccessTokenSilently.and.returnValue(of(mockJWT));
 
-    (service as any).isAdmin$().subscribe((isAdmin: boolean) => {
-      expect(isAdmin).toBe(true);
+    setTimeout(() => {
+      expect(service.isAdmin()).toBe(true);
       done();
-    });
+    }, 0);
   });
 
   it('should detect non-admin user correctly', (done) => {
@@ -102,10 +102,10 @@ describe('AuthService', () => {
 
     mockAuth0Service.getAccessTokenSilently.and.returnValue(of(mockJWT));
 
-    (service as any).isAdmin$().subscribe((isAdmin: boolean) => {
-      expect(isAdmin).toBe(false);
+    setTimeout(() => {
+      expect(service.isAdmin()).toBe(false);
       done();
-    });
+    }, 0);
   });
 
   it('should handle token error gracefully', (done) => {
@@ -113,10 +113,10 @@ describe('AuthService', () => {
       throwError(() => new Error('Token error')),
     );
 
-    (service as any).isAdmin$().subscribe((isAdmin: boolean) => {
-      expect(isAdmin).toBe(false);
+    setTimeout(() => {
+      expect(service.isAdmin()).toBe(false);
       done();
-    });
+    }, 0);
   });
 
   it('should return false for admin when not authenticated', (done) => {
@@ -140,9 +140,10 @@ describe('AuthService', () => {
     });
 
     const unauthenticatedService = TestBed.inject(AuthService);
-    (unauthenticatedService as any).isAdmin$().subscribe((isAdmin: boolean) => {
-      expect(isAdmin).toBe(false);
+
+    setTimeout(() => {
+      expect(unauthenticatedService.isAdmin()).toBe(false);
       done();
-    });
+    }, 0);
   });
 });

--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -29,7 +29,6 @@ describe('AuthService', () => {
       'logout'
     ], {
       isAuthenticated$: of(true),
-      user$: of(mockUser)
     });
 
     const docSpy = jasmine.createSpyObj('Document', [], {
@@ -71,14 +70,5 @@ describe('AuthService', () => {
 
   it('should update authentication state', () => {
     expect(service.isAuthenticated()).toBe(true);
-  });
-
-  it('should return user observable', () => {
-    const userObservable = service.getUser();
-    expect(userObservable).toBeDefined();
-    
-    userObservable.subscribe(user => {
-      expect(user).toEqual(mockUser);
-    });
   });
 });

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -74,7 +74,9 @@ export class AuthService {
   private document = inject(DOCUMENT);
 
   isAuthenticated = toSignal(this.auth0Service.isAuthenticated$, { initialValue: false });
+  isLoading = toSignal(this.auth0Service.isLoading$, { initialValue: true });
   user = toSignal(this.auth0Service.user$ as Observable<BiocommonsAuth0User | null>, { initialValue: null });
+  isAdmin = toSignal(this.isAdmin$(), { initialValue: false });
 
   login(): void {
     this.auth0Service.loginWithRedirect();
@@ -88,7 +90,7 @@ export class AuthService {
     });
   }
 
-  private decodeToken(token: string): any {
+  private decodeToken(token: string) {
     try {
       if (!token || token.split('.').length !== 3) {
         throw new Error('Invalid JWT token format');
@@ -105,7 +107,7 @@ export class AuthService {
     }
   }
 
-  isAdmin(): Observable<boolean> {
+  private isAdmin$(): Observable<boolean> {
     return this.auth0Service.isAuthenticated$.pipe(
       switchMap((isAuth) => {
         if (!isAuth) {

--- a/src/app/layouts/default-layout/default-layout.component.spec.ts
+++ b/src/app/layouts/default-layout/default-layout.component.spec.ts
@@ -1,26 +1,167 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { Router, ActivatedRoute, UrlTree } from '@angular/router';
+import { of, EMPTY } from 'rxjs';
+import { signal } from '@angular/core';
 import { DefaultLayoutComponent } from './default-layout.component';
-import { provideHttpClient } from '@angular/common/http';
-import { provideMockAuth0Service } from '../../../utils/testingUtils';
-import { provideRouter } from '@angular/router';
+import { AuthService } from '../../core/services/auth.service';
+import { ApiService } from '../../core/services/api.service';
 
 describe('DefaultLayoutComponent', () => {
   let component: DefaultLayoutComponent;
   let fixture: ComponentFixture<DefaultLayoutComponent>;
+  let mockRouter: jasmine.SpyObj<Router>;
+  let mockApiService: jasmine.SpyObj<ApiService>;
+
+  function createTestBed(
+    isAuthenticated = true,
+    isAdmin = false,
+    isLoading = false,
+    url = '/',
+  ) {
+    const authSpy = jasmine.createSpyObj('AuthService', [], {
+      isLoading: signal(isLoading),
+      isAuthenticated: signal(isAuthenticated),
+      user: signal({ name: 'Test User', picture: 'test.jpg' }),
+      isAdmin: signal(isAdmin),
+    });
+
+    const routerSpy = jasmine.createSpyObj(
+      'Router',
+      ['navigate', 'createUrlTree', 'serializeUrl'],
+      {
+        url: url,
+        events: EMPTY,
+        routerState: { root: {} },
+      },
+    );
+
+    routerSpy.createUrlTree.and.returnValue({} as UrlTree);
+    routerSpy.serializeUrl.and.returnValue('/mocked-url');
+
+    const apiSpy = jasmine.createSpyObj('ApiService', ['getAllPending']);
+
+    const activatedRouteSpy = jasmine.createSpyObj('ActivatedRoute', [], {
+      snapshot: {
+        params: {},
+        queryParams: {},
+        data: {},
+        url: [],
+        fragment: null,
+      },
+      params: of({}),
+      queryParams: of({}),
+      data: of({}),
+      url: of([]),
+      fragment: of(null),
+      root: {},
+    });
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [DefaultLayoutComponent],
+      providers: [
+        { provide: AuthService, useValue: authSpy },
+        { provide: Router, useValue: routerSpy },
+        { provide: ApiService, useValue: apiSpy },
+        { provide: ActivatedRoute, useValue: activatedRouteSpy },
+      ],
+    });
+
+    return {
+      authSpy,
+      routerSpy,
+      apiSpy,
+    };
+  }
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [DefaultLayoutComponent],
-      providers: [provideMockAuth0Service(), provideHttpClient(), provideRouter([])]
-    }).compileComponents();
+    createTestBed();
+
+    await TestBed.compileComponents();
 
     fixture = TestBed.createComponent(DefaultLayoutComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    mockRouter = TestBed.inject(Router) as jasmine.SpyObj<Router>;
+    mockApiService = TestBed.inject(ApiService) as jasmine.SpyObj<ApiService>;
+
+    mockApiService.getAllPending.and.returnValue(
+      of({ pending_services: [], pending_resources: [] }),
+    );
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should navigate to /all-users for authenticated admin users on root path', async () => {
+    createTestBed(true, true, false, '/');
+    await TestBed.compileComponents();
+
+    fixture = TestBed.createComponent(DefaultLayoutComponent);
+    component = fixture.componentInstance;
+    mockRouter = TestBed.inject(Router) as jasmine.SpyObj<Router>;
+    mockApiService = TestBed.inject(ApiService) as jasmine.SpyObj<ApiService>;
+
+    mockApiService.getAllPending.and.returnValue(
+      of({ pending_services: [], pending_resources: [] }),
+    );
+
+    fixture.detectChanges();
+
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/all-users']);
+  });
+
+  it('should navigate to /services for authenticated non-admin users on root path', async () => {
+    createTestBed(true, false, false, '/');
+    await TestBed.compileComponents();
+
+    fixture = TestBed.createComponent(DefaultLayoutComponent);
+    component = fixture.componentInstance;
+    mockRouter = TestBed.inject(Router) as jasmine.SpyObj<Router>;
+    mockApiService = TestBed.inject(ApiService) as jasmine.SpyObj<ApiService>;
+
+    mockApiService.getAllPending.and.returnValue(
+      of({ pending_services: [], pending_resources: [] }),
+    );
+
+    fixture.detectChanges();
+
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/services']);
+  });
+
+  it('should not navigate for unauthenticated users on root path', async () => {
+    createTestBed(false, false, false, '/');
+    await TestBed.compileComponents();
+
+    fixture = TestBed.createComponent(DefaultLayoutComponent);
+    component = fixture.componentInstance;
+    mockRouter = TestBed.inject(Router) as jasmine.SpyObj<Router>;
+    mockApiService = TestBed.inject(ApiService) as jasmine.SpyObj<ApiService>;
+
+    mockApiService.getAllPending.and.returnValue(
+      of({ pending_services: [], pending_resources: [] }),
+    );
+
+    fixture.detectChanges();
+
+    expect(mockRouter.navigate).not.toHaveBeenCalled();
+  });
+
+  it('should not trigger navigation logic when not on root path', async () => {
+    createTestBed(true, false, false, '/other-path');
+    await TestBed.compileComponents();
+
+    fixture = TestBed.createComponent(DefaultLayoutComponent);
+    component = fixture.componentInstance;
+    mockRouter = TestBed.inject(Router) as jasmine.SpyObj<Router>;
+    mockApiService = TestBed.inject(ApiService) as jasmine.SpyObj<ApiService>;
+
+    mockApiService.getAllPending.and.returnValue(
+      of({ pending_services: [], pending_resources: [] }),
+    );
+
+    fixture.detectChanges();
+
+    expect(mockRouter.navigate).not.toHaveBeenCalled();
   });
 });

--- a/src/app/layouts/default-layout/default-layout.component.ts
+++ b/src/app/layouts/default-layout/default-layout.component.ts
@@ -1,7 +1,10 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { FooterComponent } from "../footer/footer.component";
 import { NavbarComponent } from "../navbar/navbar.component";
-import { RouterOutlet } from "@angular/router";
+import { Router, RouterOutlet } from "@angular/router";
+import { AuthService } from '../../core/services/auth.service';
+import { AuthService as Auth0Service } from '@auth0/auth0-angular';
+import { filter, switchMap, take } from 'rxjs/operators';
 
 @Component({
   selector: 'app-default-layout',
@@ -9,4 +12,30 @@ import { RouterOutlet } from "@angular/router";
   templateUrl: './default-layout.component.html',
   styleUrl: './default-layout.component.css',
 })
-export class DefaultLayoutComponent {}
+export class DefaultLayoutComponent implements OnInit {
+  private authService = inject(AuthService);
+  private auth0Service = inject(Auth0Service);
+  private router = inject(Router);
+
+  ngOnInit() {
+    if (this.router.url === '/') {
+      this.auth0Service.isLoading$.pipe(
+        filter(isLoading => !isLoading),
+        switchMap(() => this.auth0Service.isAuthenticated$),
+        take(1),
+        switchMap(isAuthenticated => {
+          if (isAuthenticated) {
+            return this.authService.isAdmin();
+          }
+          return [false];
+        })
+      ).subscribe(isAdmin => {
+        if (isAdmin) {
+          this.router.navigate(['/all-users']);
+        } else {
+          this.router.navigate(['/services']);
+        }
+      });
+    }
+  }
+}

--- a/src/app/layouts/navbar/navbar.component.html
+++ b/src/app/layouts/navbar/navbar.component.html
@@ -1,117 +1,90 @@
-@if (!isAuthenticated()) {
-  <div
-    class="absolute left-0 top-0 z-50 flex h-full w-full flex-col items-center justify-center bg-white"
-  >
-    <div class="flex flex-col items-center justify-center">
-      <img
-        src="https://images.squarespace-cdn.com/content/5d3a4213cf4f5b00014ea1db/1689141619044-F67XDPQLP4PG6KY862VA/Australian-Biocommons-Logo-Horizontal-RGB.png?format=1500w&content-type=image%2Fpng"
-        class="auto h-16"
-        alt="Australian Biocommons Logo"
-      />
-      <h1
-        class="mt-12 text-balance text-5xl font-semibold tracking-tight text-gray-900 sm:text-7xl"
+<nav class="bg-white p-6 shadow lg:px-12">
+  <div class="flex items-center justify-between">
+    <button type="button" class="text-blue-500 hover:cursor-pointer">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke-width="1.5"
+        stroke="currentColor"
+        class="size-10"
       >
-        AAI User Portal
-      </h1>
-      <p class="my-8 font-light text-gray-400">Please log in to continue</p>
-      <div class="flex items-center justify-center gap-x-6">
-        <app-login-button />
-      </div>
-    </div>
-  </div>
-} @else {
-  <nav class="bg-white p-6 shadow lg:px-12">
-    <div class="flex items-center justify-between">
-      <button type="button" class="text-blue-500 hover:cursor-pointer">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke-width="1.5"
-          stroke="currentColor"
-          class="size-10"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25H12"
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25H12"
+        />
+      </svg>
+    </button>
+    <div class="text-2xl font-semibold text-sky-500">Dashboard</div>
+    <div class="relative">
+      <button
+        type="button"
+        class="focus:outline-hidden relative flex h-10 w-10 items-center justify-center rounded-full bg-gray-200 text-sm hover:cursor-pointer focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-blue-200"
+        id="user-menu-button"
+        aria-expanded="false"
+        aria-haspopup="true"
+        (click)="toggleUserMenu()"
+        #userMenuButton
+      >
+        <span class="absolute -inset-1.5"></span>
+        <span class="sr-only">Open user menu</span>
+        @if (user()?.picture) {
+          <img
+            class="h-10 w-10 rounded-full"
+            [src]="user()!.picture"
+            alt="User"
           />
-        </svg>
-      </button>
-      <div class="text-2xl font-semibold text-sky-500">Dashboard</div>
-      <div class="relative">
-        <button
-          type="button"
-          class="focus:outline-hidden relative flex h-10 w-10 items-center justify-center rounded-full bg-gray-200 text-sm hover:cursor-pointer focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-blue-200"
-          id="user-menu-button"
-          aria-expanded="false"
-          aria-haspopup="true"
-          (click)="toggleUserMenu()"
-          #userMenuButton
-        >
-          <span class="absolute -inset-1.5"></span>
-          <span class="sr-only">Open user menu</span>
-          @if (user()?.picture) {
-            <img
-              class="h-10 w-10 rounded-full"
-              [src]="user()!.picture"
-              alt="User"
-            />
-          }
-        </button>
-        @if (userMenuOpen) {
-          <div
-            class="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow focus:outline-none"
-            role="menu"
-            aria-orientation="vertical"
-            aria-labelledby="user-menu-button"
-            tabindex="-1"
-            #menu
-          >
-            <div
-              class="block px-4 py-2 text-sm text-gray-700 hover:cursor-pointer hover:bg-gray-100"
-              role="menuitem"
-              tabindex="-1"
-              id="user-menu-item-2"
-              (click)="logoutButton.logout()"
-              (keyup.enter)="logoutButton.logout()"
-            >
-              <app-logout-button #logoutButton />
-            </div>
-          </div>
         }
-      </div>
-    </div>
-
-    <div
-      class="align-center mt-12 flex justify-center gap-2 font-light text-sky-900 *:rounded-md *:px-6 *:py-2"
-    >
-      @for (page of getUserType(); track page) {
-        <a
-          routerLink="{{ page.route }}"
-          routerLinkActive="active"
-          class="relative bg-gray-100 hover:bg-gray-200"
-          [ngClass]="{
-            'bg-sky-900 text-white hover:bg-sky-950': isActive(page.route),
-          }"
+      </button>
+      @if (userMenuOpen()) {
+        <div
+          class="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow focus:outline-none"
+          role="menu"
+          aria-orientation="vertical"
+          aria-labelledby="user-menu-button"
+          tabindex="-1"
+          #menu
         >
-          @if (
-            (userType === "user" &&
-              page.label === "Pending" &&
-              pendingCount() > 0) ||
-            (userType === "admin" &&
-              page.label === "Requests" &&
-              pendingCount() > 0)
-          ) {
-            <span
-              class="absolute -right-2 -top-2 min-h-6 min-w-6 rounded-full bg-red-500 px-2 py-1 text-center text-xs text-white"
-            >
-              {{ pendingCount() }}
-            </span>
-          }
-          {{ page.label }}
-        </a>
+          <div
+            class="block px-4 py-2 text-sm text-gray-700 hover:cursor-pointer hover:bg-gray-100"
+            role="menuitem"
+            tabindex="-1"
+            id="user-menu-item-2"
+            (click)="logoutButton.logout()"
+            (keyup.enter)="logoutButton.logout()"
+          >
+            <app-logout-button #logoutButton />
+          </div>
+        </div>
       }
     </div>
-  </nav>
-}
+  </div>
+
+  <div
+    class="align-center mt-12 flex justify-center gap-2 font-light text-sky-900 *:rounded-md *:px-6 *:py-2"
+  >
+    @for (page of getUserType(); track page) {
+      <a
+        routerLink="{{ page.route }}"
+        routerLinkActive="active"
+        class="relative bg-gray-100 hover:bg-gray-200"
+        [ngClass]="{
+          'bg-sky-900 text-white hover:bg-sky-950': isActive(page.route),
+        }"
+      >
+        @if (
+          (!isAdmin() && page.label === "Pending" && pendingCount() > 0) ||
+          (isAdmin() && page.label === "Requests" && pendingCount() > 0)
+        ) {
+          <span
+            class="absolute -right-2 -top-2 min-h-6 min-w-6 rounded-full bg-red-500 px-2 py-1 text-center text-xs text-white"
+          >
+            {{ pendingCount() }}
+          </span>
+        }
+        {{ page.label }}
+      </a>
+    }
+  </div>
+</nav>

--- a/src/app/pages/login/login.component.html
+++ b/src/app/pages/login/login.component.html
@@ -1,6 +1,4 @@
-<div
-  class="absolute left-0 top-0 z-50 flex h-full w-full flex-col items-center justify-center overflow-hidden bg-white"
->
+<div class="flex h-full w-full flex-col items-center justify-center bg-white">
   <div class="flex flex-col items-center justify-center">
     <img
       src="https://images.squarespace-cdn.com/content/5d3a4213cf4f5b00014ea1db/1689141619044-F67XDPQLP4PG6KY862VA/Australian-Biocommons-Logo-Horizontal-RGB.png?format=1500w&content-type=image%2Fpng"

--- a/src/app/pages/login/login.component.html
+++ b/src/app/pages/login/login.component.html
@@ -1,0 +1,20 @@
+<div
+  class="absolute left-0 top-0 z-50 flex h-full w-full flex-col items-center justify-center overflow-hidden bg-white"
+>
+  <div class="flex flex-col items-center justify-center">
+    <img
+      src="https://images.squarespace-cdn.com/content/5d3a4213cf4f5b00014ea1db/1689141619044-F67XDPQLP4PG6KY862VA/Australian-Biocommons-Logo-Horizontal-RGB.png?format=1500w&content-type=image%2Fpng"
+      class="auto h-16"
+      alt="Australian Biocommons Logo"
+    />
+    <h1
+      class="mt-12 text-balance text-5xl font-semibold tracking-tight text-gray-900 sm:text-7xl"
+    >
+      AAI User Portal
+    </h1>
+    <p class="my-8 font-light text-gray-400">Please log in to continue</p>
+    <div class="flex items-center justify-center gap-x-6">
+      <app-login-button />
+    </div>
+  </div>
+</div>

--- a/src/app/pages/login/login.component.spec.ts
+++ b/src/app/pages/login/login.component.spec.ts
@@ -1,0 +1,28 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LoginComponent } from './login.component';
+import { LoginButtonComponent } from '../../shared/components/buttons/login-button/login-button.component';
+import { AuthService } from '../../core/services/auth.service';
+
+describe('LoginComponent', () => {
+  let component: LoginComponent;
+  let fixture: ComponentFixture<LoginComponent>;
+
+  beforeEach(async () => {
+    const authSpy = jasmine.createSpyObj('AuthService', ['login']);
+
+    await TestBed.configureTestingModule({
+      imports: [LoginComponent, LoginButtonComponent],
+      providers: [
+        { provide: AuthService, useValue: authSpy }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoginComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/login/login.component.ts
+++ b/src/app/pages/login/login.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { LoginButtonComponent } from '../../shared/components/buttons/login-button/login-button.component';
+
+@Component({
+  selector: 'app-login',
+  imports: [LoginButtonComponent],
+  templateUrl: './login.component.html',
+  styleUrl: './login.component.css'
+})
+export class LoginComponent {
+
+}

--- a/src/app/pages/user/services/request-service/request-service.component.ts
+++ b/src/app/pages/user/services/request-service/request-service.component.ts
@@ -6,10 +6,7 @@ import {
   ReactiveFormsModule,
   FormBuilder,
 } from '@angular/forms';
-import {
-  AuthService,
-  BiocommonsAuth0User,
-} from '../../../../core/services/auth.service';
+import { BiocommonsAuth0User } from '../../../../core/services/auth.service';
 import { LoadingSpinnerComponent } from '../../../../shared/components/loading-spinner/loading-spinner.component';
 
 interface ServiceOption {
@@ -27,7 +24,6 @@ interface ServiceOption {
 })
 export class RequestServiceComponent {
   private router = inject(Router);
-  private auth = inject(AuthService);
   private formBuilder = inject(FormBuilder);
 
   step = 0;

--- a/src/app/shared/components/buttons/login-button/login-button.component.spec.ts
+++ b/src/app/shared/components/buttons/login-button/login-button.component.spec.ts
@@ -1,26 +1,43 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { LoginButtonComponent } from './login-button.component';
-import {provideMockAuth0Service} from '../../../../../utils/testingUtils';
-import {provideHttpClient} from '@angular/common/http';
+import { AuthService } from '../../../../core/services/auth.service';
 
 describe('LoginButtonComponent', () => {
   let component: LoginButtonComponent;
   let fixture: ComponentFixture<LoginButtonComponent>;
+  let mockAuthService: jasmine.SpyObj<AuthService>;
 
   beforeEach(async () => {
+    const authSpy = jasmine.createSpyObj('AuthService', ['login']);
+
     await TestBed.configureTestingModule({
       imports: [LoginButtonComponent],
-      providers: [provideMockAuth0Service(), provideHttpClient()]
-    })
-    .compileComponents();
+      providers: [
+        { provide: AuthService, useValue: authSpy }
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(LoginButtonComponent);
     component = fixture.componentInstance;
+    mockAuthService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should call authService.login when login is called', () => {
+    component.login();
+    expect(mockAuthService.login).toHaveBeenCalled();
+  });
+
+  it('should call login when button is clicked', () => {
+    spyOn(component, 'login');
+    const button = fixture.nativeElement.querySelector('button');
+    
+    button.click();
+    
+    expect(component.login).toHaveBeenCalled();
   });
 });

--- a/src/app/shared/components/buttons/login-button/login-button.component.ts
+++ b/src/app/shared/components/buttons/login-button/login-button.component.ts
@@ -9,9 +9,9 @@ import { AuthService } from '../../../../core/services/auth.service';
   styleUrl: './login-button.component.css',
 })
 export class LoginButtonComponent {
-  private auth = inject(AuthService);
+  private authService = inject(AuthService);
 
   login() {
-    this.auth.login();
+    this.authService.login();
   }
 }

--- a/src/app/shared/components/buttons/logout-button/logout-button.component.spec.ts
+++ b/src/app/shared/components/buttons/logout-button/logout-button.component.spec.ts
@@ -1,24 +1,25 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { LogoutButtonComponent } from './logout-button.component';
-import { provideMockAuth0Service } from '../../../../../utils/testingUtils';
-import { provideHttpClient } from '@angular/common/http';
+import { AuthService } from '../../../../core/services/auth.service';
 
 describe('LogoutButtonComponent', () => {
   let component: LogoutButtonComponent;
   let fixture: ComponentFixture<LogoutButtonComponent>;
+  let mockAuthService: jasmine.SpyObj<AuthService>;
 
   beforeEach(async () => {
+    const authSpy = jasmine.createSpyObj('AuthService', ['logout']);
+
     await TestBed.configureTestingModule({
       imports: [LogoutButtonComponent],
       providers: [
-        provideMockAuth0Service({ isAuthenticated: true }),
-        provideHttpClient(),
+        { provide: AuthService, useValue: authSpy }
       ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(LogoutButtonComponent);
     component = fixture.componentInstance;
+    mockAuthService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
     fixture.detectChanges();
   });
 
@@ -26,10 +27,17 @@ describe('LogoutButtonComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should call logout() on click', () => {
-    const logoutFunction = spyOn(component, 'logout');
+  it('should call authService.logout when logout is called', () => {
+    component.logout();
+    expect(mockAuthService.logout).toHaveBeenCalled();
+  });
+
+  it('should call logout when button is clicked', () => {
+    spyOn(component, 'logout');
     const button = fixture.nativeElement.querySelector('button');
+    
     button.click();
-    expect(logoutFunction).toHaveBeenCalled();
+    
+    expect(component.logout).toHaveBeenCalled();
   });
 });

--- a/src/app/shared/components/buttons/logout-button/logout-button.component.ts
+++ b/src/app/shared/components/buttons/logout-button/logout-button.component.ts
@@ -9,9 +9,9 @@ import { AuthService } from '../../../../core/services/auth.service';
   styleUrl: './logout-button.component.css',
 })
 export class LogoutButtonComponent {
-  private auth = inject(AuthService);
+  private authService = inject(AuthService);
 
   logout() {
-    this.auth.logout();
+    this.authService.logout();
   }
 }


### PR DESCRIPTION
## Description

[AAI-255](https://biocloud.atlassian.net/jira/software/c/projects/AAI/boards/53?assignee=63f30233526117e1514b222b&selectedIssue=AAI-255): admin token validation for AAI portal admin page

The portal now checks the user role in the token and redirects users to the appropriate UI (users to the user UI, admins to the admin UI), with strict route guards in place to prevent unauthorized access to specific routes.

## Changes

- Refactored Auth Service to be signal-based
- Added token validation and role checks (currently only checks for the admin role, but this can be expanded to check for specific roles in GitHub secrets in future iterations)
- Handled role-based redirects within the Default Layout component
- Updated routes with additional guards:
	•	Auth Guard: Protects routes that require authentication
	•	Login Guard: Prevents access to the login route when the user is already authenticated (acts as the inverse of the Auth Guard)
	•	Admin Guard: Restricts access to admin-only routes (prevents regular users from accessing these)
	•	User Guard: Restricts access to user-only routes (prevents admins from accessing
- Added a separate login route instead of relying on the navbar as a temporary login interface
- Added all relevant tests

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

## How to Test Manually

Assign admin role to user in Auth0 and then log into the AAI Portal

