### PR TITLE
Update galaxy registration token URL so it doesn't get intercepted by Auth0

### DIFF
--- a/src/app/pages/galaxy/register/galaxy-register.component.spec.ts
+++ b/src/app/pages/galaxy/register/galaxy-register.component.spec.ts
@@ -121,7 +121,7 @@ describe('GalaxyRegisterComponent submission', () => {
 
     // Expect token request
     const tokenReq = httpMock.expectOne(
-      `${environment.auth0.backend}/galaxy/get-registration-token`
+      `${environment.auth0.backend}/galaxy/register/get-registration-token`
     );
     tokenReq.flush({ token: 'mock-token' });
 
@@ -142,7 +142,7 @@ describe('GalaxyRegisterComponent submission', () => {
     fillFormWithValidData();
 
     component.onSubmit();
-    const tokenReq = httpMock.expectOne(`${environment.auth0.backend}/galaxy/get-registration-token`);
+    const tokenReq = httpMock.expectOne(`${environment.auth0.backend}/galaxy/register/get-registration-token`);
     tokenReq.flush("", {status: 500, statusText: "Token request failed"});
 
     tick();
@@ -157,7 +157,7 @@ describe('GalaxyRegisterComponent submission', () => {
     fillFormWithValidData();
 
     component.onSubmit();
-    const tokenReq = httpMock.expectOne(`${environment.auth0.backend}/galaxy/get-registration-token`);
+    const tokenReq = httpMock.expectOne(`${environment.auth0.backend}/galaxy/register/get-registration-token`);
     tokenReq.flush({ token: 'mock-token' });
 
     const registerReq = httpMock.expectOne(`${environment.auth0.backend}/galaxy/register`);

--- a/src/app/pages/galaxy/register/galaxy-register.component.ts
+++ b/src/app/pages/galaxy/register/galaxy-register.component.ts
@@ -108,7 +108,7 @@ export class GalaxyRegisterComponent {
 
     this.http
       .get<GalaxyRegistrationToken>(
-        `${environment.auth0.backend}/galaxy/get-registration-token`,
+        `${environment.auth0.backend}/galaxy/register/get-registration-token`,
       )
       .pipe(
         switchMap((response) => {


### PR DESCRIPTION
## Description

We use a registration token in the Galaxy registration to discourage bot requests, it currently gets intercepted by the authInterceptor because it doesn't include `/register` in the URL. Updating the URL to include `/register` is the simplest fix as it's registration-related anyway