### PR TITLE
AAI-288 fix username requirements: max length of 128 to match Auth0

### DIFF
--- a/src/utils/validation/usernames.spec.ts
+++ b/src/utils/validation/usernames.spec.ts
@@ -36,7 +36,7 @@ describe('usernameRequirements', () => {
 
   it('should validate maximum length', () => {
     // Arrange
-    const tooLongUsername = 'a'.repeat(101); // 101 characters
+    const tooLongUsername = 'a'.repeat(129);
     const control = new FormControl(tooLongUsername);
 
     // Act

--- a/src/utils/validation/usernames.ts
+++ b/src/utils/validation/usernames.ts
@@ -1,5 +1,8 @@
 import { AbstractControl, Validators } from '@angular/forms';
 
+const USERNAME_MIN_LENGTH = 3;
+const USERNAME_MAX_LENGTH = 128;
+
 interface UsernameErrors {
   required?: boolean;
   minlength?: {requiredLength: number, actualLength: number};
@@ -8,11 +11,17 @@ interface UsernameErrors {
 }
 
 
+/**
+ * Validate requirements for our usernames in Auth0.
+ * Min length of 3 (based on platform requirements)
+ * Max length of 128 (from Auth0)
+ * lowercase letters, digits, hyphen and underscore only (based on platform requirements)
+ */
 export function usernameRequirements(control: AbstractControl): UsernameErrors | null {
   const validator = Validators.compose([
     Validators.required,
-    Validators.minLength(3),
-    Validators.maxLength(100),
+    Validators.minLength(USERNAME_MIN_LENGTH),
+    Validators.maxLength(USERNAME_MAX_LENGTH),
     Validators.pattern(/^[a-z0-9_-]+$/),
   ])
   return validator!(control);


### PR DESCRIPTION
## Description

[AAI-288](https://biocloud.atlassian.net/browse/AAI-288): updating max length to 128 to match Auth0 (also done in the backend)

## Changes

- Update max length in usernameRequirements validator
- Update unit tests

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

## How to Test Manually

Run `ng test`


[AAI-288]: https://biocloud.atlassian.net/browse/AAI-288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ