### PR TITLE
AAI-305: need the registration_info endpoint to bypass the auth interceptor

### DIFF
--- a/src/app/core/interceptors/auth.interceptor.spec.ts
+++ b/src/app/core/interceptors/auth.interceptor.spec.ts
@@ -1,0 +1,91 @@
+// auth.interceptor.spec.ts
+import { TestBed } from '@angular/core/testing';
+import { HttpClient } from '@angular/common/http';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+
+import { of } from 'rxjs';
+import { AuthService as Auth0Service } from '@auth0/auth0-angular';
+import { authInterceptor } from './auth.interceptor';
+import { environment } from '../../../environments/environment';
+
+describe('authInterceptor (bypass URLs)', () => {
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+
+  // Simple spyable mock for Auth0Service
+  const auth0Mock = {
+    getAccessTokenSilently: jasmine
+      .createSpy('getAccessTokenSilently')
+      .and.returnValue(of('test-token')),
+  };
+
+  const backend = environment.auth0.backend; // e.g. 'https://api.example.com'
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: Auth0Service, useValue: auth0Mock },
+        provideHttpClient(withInterceptors([authInterceptor])),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+    auth0Mock.getAccessTokenSilently.calls.reset();
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  // List of backend paths that should bypass auth
+  const BYPASS_PATHS: readonly string[] = [
+    '/register',
+    '/utils/registration_info',
+  ] as const;
+
+  BYPASS_PATHS.forEach((path) => {
+    it(`should NOT attach token for bypass path: ${path}`, () => {
+      const url = `${backend}${path}`;
+
+      http.get(url).subscribe();
+      const req = httpMock.expectOne(url);
+
+      expect(auth0Mock.getAccessTokenSilently).not.toHaveBeenCalled();
+      expect(req.request.headers.has('Authorization')).toBeFalse();
+      expect(req.request.headers.has('Content-Type')).toBeFalse();
+
+      req.flush({ ok: true });
+    });
+  });
+
+  it('should attach token for other backend URLs (non-bypass control)', () => {
+    const url = `${backend}/users/me`;
+
+    http.get(url).subscribe();
+    const req = httpMock.expectOne(url);
+
+    // For non-bypass backend, token should be requested and header set
+    expect(auth0Mock.getAccessTokenSilently).toHaveBeenCalledTimes(1);
+    expect(req.request.headers.get('Authorization')).toBe('Bearer test-token');
+    expect(req.request.headers.get('Content-Type')).toBe('application/json');
+
+    req.flush({ ok: true });
+  });
+
+  it('should leave non-backend URLs untouched (extra safety)', () => {
+    const url = `https://other.example.com/public`;
+
+    http.get(url).subscribe();
+    const req = httpMock.expectOne(url);
+
+    expect(auth0Mock.getAccessTokenSilently).not.toHaveBeenCalled();
+    expect(req.request.headers.has('Authorization')).toBeFalse();
+    expect(req.request.headers.has('Content-Type')).toBeFalse();
+
+    req.flush({ ok: true });
+  });
+});

--- a/src/app/core/interceptors/auth.interceptor.ts
+++ b/src/app/core/interceptors/auth.interceptor.ts
@@ -6,16 +6,25 @@ import { throwError } from 'rxjs';
 import { environment } from '../../../environments/environment';
 
 /**
+ * Backend endpoints that don't need an access token
+ * (because they involve registration, where the user won't
+ * be logged in)
+ */
+const BYPASS_URLS = [
+  '/register',
+  '/utils/registration_info',
+] as readonly string[];
+/**
  * HTTP interceptor that adds the Auth0 access token to requests sent to the AAI backend API
  */
 export const authInterceptor: HttpInterceptorFn = (req, next) => {
   const auth0Service = inject(Auth0Service);
 
   const isBackendRequest = req.url.includes(environment.auth0.backend);
-  const isRegistrationEndpoint = req.url.includes('/register');
+  const isBypassUrl = BYPASS_URLS.some((path) => req.url.includes(path));
 
   // For requests to the AAI backend that's not a registration endpoint
-  if (isBackendRequest && !isRegistrationEndpoint) {
+  if (isBackendRequest && !isBypassUrl) {
     return auth0Service.getAccessTokenSilently().pipe(
       switchMap((token) => {
         // Add Bearer token to request headers


### PR DESCRIPTION
## Description

[AAI-305](https://biocloud.atlassian.net/browse/AAI-305): the issue occurs when not logged in because the frontend app intercepts the registration_info request. This endpoint needs to work for non-logged in users, so needs to bypass the interceptor

## Changes

- Add `/utils/registration_info` to the check for bypassed URLs
- Add unit tests for the interceptor

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit / integration tests that prove my fix is effective or that my feature works
- [ ] I have run all tests locally and they pass
- [ ] I have updated the documentation (if applicable)

## How to Test Manually

Run `ng test`
