### PR TITLE
AAI-289: better display of registration errors

### DIFF
--- a/src/app/core/services/validation.service.spec.ts
+++ b/src/app/core/services/validation.service.spec.ts
@@ -285,4 +285,49 @@ describe('ValidationService', () => {
       expect(errors).not.toContain('Default required message');
     });
   });
+
+  describe('setBackendErrorMessages', () => {
+    it('should process backend field errors and make fields invalid', () => {
+      // Create a mock HTTP error response with field errors
+      const mockErrorResponse = {
+        error: {
+          message: 'Registration failed',
+          field_errors: [
+            { field: 'username', message: 'Username already exists' },
+            { field: 'email', message: 'Email is already registered' },
+          ],
+        },
+      } as HttpErrorResponse;
+
+      // Call setBackendErrorMessages
+      service.setBackendErrorMessages(mockErrorResponse);
+
+      // Fields should now be invalid due to backend errors
+      expect(service.isFieldInvalid(testForm, 'username')).toBeTrue();
+      expect(service.isFieldInvalid(testForm, 'email')).toBeTrue();
+    });
+
+    it('should return backend error messages when calling getErrorMessages', () => {
+      // Create a mock HTTP error response with field errors
+      const mockErrorResponse = {
+        error: {
+          message: 'Registration failed',
+          field_errors: [
+            { field: 'username', message: 'Username already exists' },
+            { field: 'email', message: 'Email is already registered' },
+          ],
+        },
+      } as HttpErrorResponse;
+
+      // Call setBackendErrorMessages
+      service.setBackendErrorMessages(mockErrorResponse);
+
+      // Should return the backend error messages
+      const usernameErrors = service.getErrorMessages(testForm, 'username');
+      const emailErrors = service.getErrorMessages(testForm, 'email');
+
+      expect(usernameErrors).toContain('Username already exists');
+      expect(emailErrors).toContain('Email is already registered');
+    });
+  });
 });

--- a/src/app/core/services/validation.service.spec.ts
+++ b/src/app/core/services/validation.service.spec.ts
@@ -1,8 +1,17 @@
 import { TestBed } from '@angular/core/testing';
-import { FormBuilder, FormGroup, Validators, FormControl } from '@angular/forms';
+import {
+  FormBuilder,
+  FormGroup,
+  Validators,
+  FormControl,
+} from '@angular/forms';
 import { ValidationService } from './validation.service';
-import { ALLOWED_SPECIAL_CHARACTERS, passwordRequirements } from '../../../utils/validation/passwords';
+import {
+  ALLOWED_SPECIAL_CHARACTERS,
+  passwordRequirements,
+} from '../../../utils/validation/passwords';
 import { usernameRequirements } from '../../../utils/validation/usernames';
+import { HttpErrorResponse } from '@angular/common/http';
 
 describe('ValidationService', () => {
   let service: ValidationService;
@@ -11,7 +20,7 @@ describe('ValidationService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [ValidationService, FormBuilder]
+      providers: [ValidationService, FormBuilder],
     });
 
     service = TestBed.inject(ValidationService);
@@ -21,7 +30,7 @@ describe('ValidationService', () => {
     testForm = formBuilder.group({
       username: ['', [usernameRequirements]],
       email: ['', [Validators.required, Validators.email]],
-      password: ['', [passwordRequirements]]
+      password: ['', [passwordRequirements]],
     });
   });
 
@@ -34,7 +43,7 @@ describe('ValidationService', () => {
       testForm.patchValue({
         username: 'validuser',
         email: 'test@example.com',
-        password: 'ValidPassword123!'
+        password: 'ValidPassword123!',
       });
 
       expect(service.isFieldInvalid(testForm, 'username')).toBeFalse();
@@ -81,7 +90,7 @@ describe('ValidationService', () => {
       testForm.patchValue({
         username: 'validuser',
         email: 'test@example.com',
-        password: 'ValidPassword123!'
+        password: 'ValidPassword123!',
       });
 
       expect(service.getErrorMessages(testForm, 'username')).toEqual([]);
@@ -93,8 +102,12 @@ describe('ValidationService', () => {
       testForm.get('username')?.markAsTouched();
       testForm.get('email')?.markAsTouched();
 
-      expect(service.getErrorMessages(testForm, 'username')).toContain('This field is required');
-      expect(service.getErrorMessages(testForm, 'email')).toContain('This field is required');
+      expect(service.getErrorMessages(testForm, 'username')).toContain(
+        'This field is required',
+      );
+      expect(service.getErrorMessages(testForm, 'email')).toContain(
+        'This field is required',
+      );
     });
 
     it('should return field-specific error messages for username', () => {
@@ -115,7 +128,10 @@ describe('ValidationService', () => {
 
     it('should return default error messages when field-specific ones are not available', () => {
       // Add a field without specific error messages
-      testForm.addControl('genericField', new FormControl('', Validators.required));
+      testForm.addControl(
+        'genericField',
+        new FormControl('', Validators.required),
+      );
       testForm.get('genericField')?.markAsTouched();
 
       const errors = service.getErrorMessages(testForm, 'genericField');
@@ -123,7 +139,9 @@ describe('ValidationService', () => {
     });
 
     it('should handle non-existent fields', () => {
-      expect(service.getErrorMessages(testForm, 'nonExistentField')).toEqual([]);
+      expect(service.getErrorMessages(testForm, 'nonExistentField')).toEqual(
+        [],
+      );
     });
 
     it('should include special characters in password error message', () => {
@@ -133,7 +151,9 @@ describe('ValidationService', () => {
 
       const errors = service.getErrorMessages(testForm, 'password');
       const expectedErrorMessage = `Password must contain at least one special character (${ALLOWED_SPECIAL_CHARACTERS})`;
-      expect(errors.some(msg => msg.includes(expectedErrorMessage))).toBeTrue();
+      expect(
+        errors.some((msg) => msg.includes(expectedErrorMessage)),
+      ).toBeTrue();
     });
   });
 
@@ -141,7 +161,7 @@ describe('ValidationService', () => {
     it('should add new error messages for a field', () => {
       // Add custom error messages for a new field
       service.addFieldErrorMessages('customField', {
-        'custom': 'This is a custom error message'
+        custom: 'This is a custom error message',
       });
 
       // Create a control with the custom error
@@ -156,7 +176,7 @@ describe('ValidationService', () => {
     it('should override existing error messages for a field', () => {
       // Override existing username error message
       service.addFieldErrorMessages('username', {
-        'minlength': 'Custom minlength message'
+        minlength: 'Custom minlength message',
       });
 
       testForm.patchValue({ username: 'ab' });
@@ -170,7 +190,7 @@ describe('ValidationService', () => {
     it('should merge new error messages with existing ones', () => {
       // Add a new error message to username without overriding existing ones
       service.addFieldErrorMessages('username', {
-        'newError': 'This is a new error type'
+        newError: 'This is a new error type',
       });
 
       // Create control with both errors
@@ -189,7 +209,7 @@ describe('ValidationService', () => {
     it('should add new default error messages', () => {
       // Add a custom default error message
       service.addDefaultErrorMessages({
-        'customDefault': 'This is a custom default error'
+        customDefault: 'This is a custom default error',
       });
 
       // Create a control with the custom error
@@ -204,7 +224,7 @@ describe('ValidationService', () => {
     it('should override existing default error messages', () => {
       // Override the default 'required' error message
       service.addDefaultErrorMessages({
-        'required': 'Field must be filled out'
+        required: 'Field must be filled out',
       });
 
       testForm.get('username')?.markAsTouched();
@@ -217,7 +237,7 @@ describe('ValidationService', () => {
     it('should merge new default error messages with existing ones', () => {
       // Add a new default error without overriding existing ones
       service.addDefaultErrorMessages({
-        'newDefaultError': 'This is a new default error type'
+        newDefaultError: 'This is a new default error type',
       });
 
       // Create control with both errors
@@ -248,11 +268,11 @@ describe('ValidationService', () => {
     it('should prioritize field-specific error messages over default ones', () => {
       // Add a field-specific and default error message for the same error
       service.addFieldErrorMessages('testField', {
-        'required': 'Field-specific required message'
+        required: 'Field-specific required message',
       });
 
       service.addDefaultErrorMessages({
-        'required': 'Default required message'
+        required: 'Default required message',
       });
 
       // Create a control with the required error

--- a/src/app/core/services/validation.service.ts
+++ b/src/app/core/services/validation.service.ts
@@ -1,6 +1,11 @@
 import { Injectable } from '@angular/core';
 import { FormGroup, ValidationErrors } from '@angular/forms';
 import { ALLOWED_SPECIAL_CHARACTERS } from '../../../utils/validation/passwords';
+import { HttpErrorResponse } from '@angular/common/http';
+import {
+  RegistrationErrorResponse,
+  RegistrationFieldError,
+} from '../../shared/types/backend.types';
 
 /**
  * Form validation service to reuse across our registration forms.
@@ -35,6 +40,32 @@ export class ValidationService {
     },
   };
 
+  private backendErrorMessages: Record<string, string> = {};
+
+  setBackendErrorMessages(response: HttpErrorResponse) {
+    function isRegistrationError(
+      error: unknown,
+    ): error is RegistrationErrorResponse {
+      return (
+        typeof error === 'object' &&
+        error !== null &&
+        'message' in error &&
+        'field_errors' in error
+      );
+    }
+    if (isRegistrationError(response.error)) {
+      response.error.field_errors.forEach(
+        (fieldError: RegistrationFieldError) => {
+          this.backendErrorMessages[fieldError.field] = fieldError.message;
+        },
+      );
+    }
+  }
+
+  reset() {
+    this.backendErrorMessages = {};
+  }
+
   /**
    * Gets error messages for a form control
    * @param form The form group containing the control
@@ -42,11 +73,13 @@ export class ValidationService {
    * @returns Array of error messages
    */
   getErrorMessages(form: FormGroup, fieldName: string): string[] {
-    const control = form.get(fieldName);
-    if (!control?.errors) return [];
+    const control = form.get(fieldName)!;
+    const inputValid = !control?.errors;
+    const backendValid = !this.backendErrorMessages[fieldName];
+    if (inputValid && backendValid) return [];
 
     // Return all error messages that apply to this control
-    return Object.keys(control.errors)
+    const inputErrors = Object.keys(control.errors || {})
       .filter(
         (key) =>
           this.fieldSpecificErrorMessages[fieldName]?.[key] ||
@@ -58,6 +91,10 @@ export class ValidationService {
           this.defaultErrorMessages[key] ||
           `Error: ${key}`,
       );
+    if (this.backendErrorMessages[fieldName]) {
+      inputErrors.push(this.backendErrorMessages[fieldName]);
+    }
+    return inputErrors;
   }
 
   /**
@@ -68,7 +105,8 @@ export class ValidationService {
    */
   isFieldInvalid(form: FormGroup, fieldName: string): boolean {
     const field = form.get(fieldName);
-    return !!(field?.invalid && (field?.dirty || field?.touched));
+    const invalidInput = !!(field?.invalid && (field?.dirty || field?.touched));
+    return invalidInput || !!this.backendErrorMessages[fieldName];
   }
 
   /**

--- a/src/app/core/services/validation.service.ts
+++ b/src/app/core/services/validation.service.ts
@@ -42,7 +42,12 @@ export class ValidationService {
 
   private backendErrorMessages: Record<string, string> = {};
 
+  /**
+   * Processes the error response from the backend and sets the error messages
+   * for the form fields that are invalid.
+   */
   setBackendErrorMessages(response: HttpErrorResponse) {
+    // Check if the response matches our expected format
     function isRegistrationError(
       error: unknown,
     ): error is RegistrationErrorResponse {
@@ -53,6 +58,7 @@ export class ValidationService {
         'field_errors' in error
       );
     }
+
     if (isRegistrationError(response.error)) {
       response.error.field_errors.forEach(
         (fieldError: RegistrationFieldError) => {
@@ -62,6 +68,9 @@ export class ValidationService {
     }
   }
 
+  /**
+   * Resets the backend error messages for all fields.
+   */
   reset() {
     this.backendErrorMessages = {};
   }

--- a/src/app/pages/bpa/register/bpa-register.component.spec.ts
+++ b/src/app/pages/bpa/register/bpa-register.component.spec.ts
@@ -198,7 +198,7 @@ describe('BpaRegisterComponent', () => {
       expect(req.request.method).toBe('POST');
 
       req.flush(
-        { detail: 'Registration failed' },
+        { message: 'Registration failed' },
         { status: 400, statusText: 'Bad Request' },
       );
 

--- a/src/app/pages/bpa/register/bpa-register.component.ts
+++ b/src/app/pages/bpa/register/bpa-register.component.ts
@@ -2,7 +2,7 @@ import { Component, inject, signal } from '@angular/core';
 import { Router, RouterLink, ActivatedRoute } from '@angular/router';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { CommonModule } from '@angular/common';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { environment } from '../../../../environments/environment';
 import { usernameRequirements } from '../../../../utils/validation/usernames';
 import { passwordRequirements } from '../../../../utils/validation/passwords';
@@ -149,7 +149,10 @@ export class BpaRegisterComponent {
       this.http.post(this.backendURL, requestBody).subscribe({
         next: () =>
           this.router.navigate(['success'], { relativeTo: this.route }),
-        error: (error) => this.showErrorNotification(error?.error?.detail),
+        error: (error: HttpErrorResponse) => {
+          this.showErrorNotification(error?.error?.message);
+          this.validationService.setBackendErrorMessages(error);
+        },
       });
     } else {
       this.registrationForm.markAllAsTouched();
@@ -184,6 +187,7 @@ export class BpaRegisterComponent {
     });
     this.registrationForm.markAsPristine();
     this.registrationForm.markAsUntouched();
+    this.validationService.reset();
     this.recaptchaToken = null;
     this.recaptchaAttempted = false;
   }

--- a/src/app/pages/galaxy/register/galaxy-register.component.ts
+++ b/src/app/pages/galaxy/register/galaxy-register.component.ts
@@ -6,7 +6,11 @@ import {
   ReactiveFormsModule,
   Validators,
 } from '@angular/forms';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import {
+  HttpClient,
+  HttpErrorResponse,
+  HttpHeaders,
+} from '@angular/common/http';
 import { Router, ActivatedRoute } from '@angular/router';
 import { catchError, of, switchMap } from 'rxjs';
 import { LoadingSpinnerComponent } from '../../../shared/components/loading-spinner/loading-spinner.component';
@@ -117,9 +121,10 @@ export class GalaxyRegisterComponent {
             },
           );
         }),
-        catchError((error) => {
-          console.error('Registration failed:', error);
-          this.errorMessage = error?.message || 'Registration failed';
+        catchError((response: HttpErrorResponse) => {
+          console.error('Registration failed:', response);
+          this.validationService.setBackendErrorMessages(response);
+          this.errorMessage = response?.error?.message || 'Registration failed';
           document.getElementById('register_error_message')?.scrollIntoView();
           return of(null); // return observable to allow subscription to complete
         }),
@@ -127,6 +132,7 @@ export class GalaxyRegisterComponent {
       .subscribe((result) => {
         if (result) {
           this.errorMessage = null;
+          this.validationService.reset();
           this.registerForm.reset();
           this.router.navigate(['success'], { relativeTo: this.route });
         }

--- a/src/app/pages/register/register.component.ts
+++ b/src/app/pages/register/register.component.ts
@@ -8,7 +8,7 @@ import {
   FormControl,
 } from '@angular/forms';
 import { CommonModule } from '@angular/common';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { catchError, of } from 'rxjs';
 import { AuthService } from '../../core/services/auth.service';
 import { biocommonsBundles, Bundle } from '../../core/constants/constants';
@@ -190,6 +190,7 @@ export class RegisterComponent {
       case 2:
         this.registrationForm.markAsUntouched();
         this.registrationForm.markAsPristine();
+        this.validationService.reset();
         this.recaptchaToken = null;
         this.recaptchaAttempted = false;
         break;
@@ -243,12 +244,11 @@ export class RegisterComponent {
         registrationData,
       )
       .pipe(
-        catchError((error) => {
+        catchError((error: HttpErrorResponse) => {
           console.error('Registration failed:', error);
+          this.validationService.setBackendErrorMessages(error);
           this.errorMessage =
-            error?.error?.detail ||
-            error?.message ||
-            'Registration failed. Please try again.';
+            error?.error?.message || 'Registration failed. Please try again.';
           this.isSubmitting = false;
           window.scrollTo({ top: 0, behavior: 'smooth' });
           return of(null);

--- a/src/app/shared/types/backend.types.ts
+++ b/src/app/shared/types/backend.types.ts
@@ -1,0 +1,9 @@
+export interface RegistrationFieldError {
+  field: string;
+  message: string;
+}
+
+export interface RegistrationErrorResponse {
+  message: string;
+  field_errors: RegistrationFieldError[];
+}


### PR DESCRIPTION
## Description

[AAI-289](https://biocloud.atlassian.net/browse/AAI-289): now that we have standardised how the backend reports registration errors, we can process them in a standardised way, and display error messages for individual fields if needed

## Changes

- Add handling of backend errors to the validation service
- Add backend errors to all 3 registration forms (Galaxy, BPA DP, BioCommons)
- Tests for validation service's error handling

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

## How to Test Manually

Register with a duplicate username on any registration form.

## Screenshots for any UI changes

Examples of individual field errors below. We can improve the wording of these in the backend, and ideally we should not actually see these errors because they will be caught by frontend validation first. But this shows we can get field-specific errors back from the backend.

<img width="1145" height="635" alt="Screenshot 2025-08-25 at 1 19 09 pm" src="https://github.com/user-attachments/assets/2cb39b2f-9470-4a3f-989f-95650a98f706" />


[AAI-289]: https://biocloud.atlassian.net/browse/AAI-289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ