### PR TITLE
AAI-273 Integrate admin check in the front-end

### DIFF
--- a/src/app/core/guards/admin.guard.spec.ts
+++ b/src/app/core/guards/admin.guard.spec.ts
@@ -7,15 +7,16 @@ import {
 import { adminGuard } from './admin.guard';
 import { AuthService } from '../services/auth.service';
 import { signal } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 
 describe('adminGuard', () => {
   let mockAuthService: jasmine.SpyObj<AuthService>;
   let mockRouter: jasmine.SpyObj<Router>;
 
   beforeEach(() => {
-    const authSpy = jasmine.createSpyObj('AuthService', ['isAuthenticated', 'isAdmin'], {
+    const authSpy = jasmine.createSpyObj('AuthService', ['isAuthenticated'], {
       isLoading: signal(false),
+      isAdmin$: of(false),
     });
     const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
 
@@ -26,7 +27,9 @@ describe('adminGuard', () => {
       ],
     });
 
-    mockAuthService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
+    mockAuthService = TestBed.inject(
+      AuthService,
+    ) as jasmine.SpyObj<AuthService>;
     mockRouter = TestBed.inject(Router) as jasmine.SpyObj<Router>;
   });
 
@@ -37,7 +40,10 @@ describe('adminGuard', () => {
 
   it('should return true when user is authenticated and is admin', (done) => {
     mockAuthService.isAuthenticated.and.returnValue(true);
-    mockAuthService.isAdmin.and.returnValue(true);
+    Object.defineProperty(mockAuthService, 'isAdmin$', {
+      value: of(true),
+      writable: true,
+    });
 
     const result = TestBed.runInInjectionContext(() =>
       adminGuard({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
@@ -52,7 +58,10 @@ describe('adminGuard', () => {
 
   it('should return false and navigate to home when user is not admin', (done) => {
     mockAuthService.isAuthenticated.and.returnValue(true);
-    mockAuthService.isAdmin.and.returnValue(false);
+    Object.defineProperty(mockAuthService, 'isAdmin$', {
+      value: of(false),
+      writable: true,
+    });
 
     const result = TestBed.runInInjectionContext(() =>
       adminGuard({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
@@ -67,7 +76,6 @@ describe('adminGuard', () => {
 
   it('should return false and navigate to home when user is not authenticated', (done) => {
     mockAuthService.isAuthenticated.and.returnValue(false);
-    mockAuthService.isAdmin.and.returnValue(false);
 
     const result = TestBed.runInInjectionContext(() =>
       adminGuard({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),

--- a/src/app/core/guards/admin.guard.ts
+++ b/src/app/core/guards/admin.guard.ts
@@ -2,25 +2,33 @@ import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
 import { AuthService } from '../services/auth.service';
 import { toObservable } from '@angular/core/rxjs-interop';
-import { filter, map, take } from 'rxjs/operators';
+import { filter, map, take, switchMap } from 'rxjs/operators';
+import { of } from 'rxjs';
 
 export const adminGuard: CanActivateFn = () => {
   const authService = inject(AuthService);
   const router = inject(Router);
 
   return toObservable(authService.isLoading).pipe(
-    filter(isLoading => !isLoading),
+    filter((isLoading) => !isLoading),
     take(1),
-    map(() => {
-      const isAuthenticated = authService.isAuthenticated();
-      const isAdmin = authService.isAdmin();
-      
-      if (isAuthenticated && isAdmin) {
-        return true;
-      } else {
+    switchMap(() => {
+      if (!authService.isAuthenticated()) {
         router.navigate(['/']);
-        return false;
+        return of(false);
       }
-    })
+
+      return authService.isAdmin$.pipe(
+        take(1),
+        map((isAdmin) => {
+          if (isAdmin) {
+            return true;
+          } else {
+            router.navigate(['/']);
+            return false;
+          }
+        }),
+      );
+    }),
   );
 };

--- a/src/app/core/services/api.service.spec.ts
+++ b/src/app/core/services/api.service.spec.ts
@@ -1,6 +1,10 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import {
+  provideHttpClientTesting,
+  HttpTestingController,
+} from '@angular/common/http/testing';
 import { ApiService } from './api.service';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { environment } from '../../../environments/environment';
 
 describe('ApiService', () => {
@@ -9,10 +13,9 @@ describe('ApiService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
-      providers: [ApiService]
+      providers: [ApiService, provideHttpClient(), provideHttpClientTesting()],
     });
-    
+
     service = TestBed.inject(ApiService);
     httpMock = TestBed.inject(HttpTestingController);
   });
@@ -26,58 +29,78 @@ describe('ApiService', () => {
   });
 
   it('should fetch approved services', () => {
-    const mockResponse = { 
+    const mockResponse = {
       approved_services: [
-        { id: '1', name: 'Test Service', status: 'active', last_updated: '', updated_by: '', resources: [] }
-      ] 
+        {
+          id: '1',
+          name: 'Test Service',
+          status: 'active',
+          last_updated: '',
+          updated_by: '',
+          resources: [],
+        },
+      ],
     };
 
-    service.getApprovedServices().subscribe(response => {
+    service.getApprovedServices().subscribe((response) => {
       expect(response).toEqual(mockResponse);
       expect(response.approved_services.length).toBe(1);
       expect(response.approved_services[0].name).toBe('Test Service');
     });
 
-    const req = httpMock.expectOne(`${environment.auth0.backend}/me/services/approved`);
+    const req = httpMock.expectOne(
+      `${environment.auth0.backend}/me/services/approved`,
+    );
     expect(req.request.method).toBe('GET');
     req.flush(mockResponse);
   });
 
   it('should fetch approved resources', () => {
-    const mockResponse = { 
+    const mockResponse = {
       approved_resources: [
-        { id: '1', name: 'Test Resource', status: 'active' }
-      ] 
+        { id: '1', name: 'Test Resource', status: 'active' },
+      ],
     };
 
-    service.getApprovedResources().subscribe(response => {
+    service.getApprovedResources().subscribe((response) => {
       expect(response).toEqual(mockResponse);
       expect(response.approved_resources.length).toBe(1);
       expect(response.approved_resources[0].name).toBe('Test Resource');
     });
 
-    const req = httpMock.expectOne(`${environment.auth0.backend}/me/resources/approved`);
+    const req = httpMock.expectOne(
+      `${environment.auth0.backend}/me/resources/approved`,
+    );
     expect(req.request.method).toBe('GET');
     req.flush(mockResponse);
   });
 
   it('should fetch all pending items', () => {
-    const mockResponse = { 
+    const mockResponse = {
       pending_services: [
-        { id: '1', name: 'Pending Service', status: 'pending', last_updated: '', updated_by: '', resources: [] }
-      ], 
+        {
+          id: '1',
+          name: 'Pending Service',
+          status: 'pending',
+          last_updated: '',
+          updated_by: '',
+          resources: [],
+        },
+      ],
       pending_resources: [
-        { id: '2', name: 'Pending Resource', status: 'pending' }
-      ] 
+        { id: '2', name: 'Pending Resource', status: 'pending' },
+      ],
     };
 
-    service.getAllPending().subscribe(response => {
+    service.getAllPending().subscribe((response) => {
       expect(response).toEqual(mockResponse);
-      expect(response.pending_services.length).toBe(1); 
+      expect(response.pending_services.length).toBe(1);
       expect(response.pending_resources.length).toBe(1);
     });
 
-    const req = httpMock.expectOne(`${environment.auth0.backend}/me/all/pending`);
+    const req = httpMock.expectOne(
+      `${environment.auth0.backend}/me/all/pending`,
+    );
     expect(req.request.method).toBe('GET');
     req.flush(mockResponse);
   });
@@ -85,12 +108,14 @@ describe('ApiService', () => {
   it('should handle empty responses', () => {
     const mockResponse = { pending_services: [], pending_resources: [] };
 
-    service.getAllPending().subscribe(response => {
+    service.getAllPending().subscribe((response) => {
       expect(response.pending_services).toEqual([]);
       expect(response.pending_resources).toEqual([]);
     });
 
-    const req = httpMock.expectOne(`${environment.auth0.backend}/me/all/pending`);
+    const req = httpMock.expectOne(
+      `${environment.auth0.backend}/me/all/pending`,
+    );
     req.flush(mockResponse);
   });
 });

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -85,6 +85,7 @@ export class AuthService {
     { initialValue: null },
   );
 
+  // Observable that checks if the current user has admin privileges
   isAdmin$ = this.auth0Service.isAuthenticated$.pipe(
     switchMap((isAuth) =>
       isAuth
@@ -103,6 +104,9 @@ export class AuthService {
           )
         : of(false),
     ),
+    // shareReplay(1) ensures multiple subscribers share the same HTTP request
+    // and new subscribers immediately get the last cached admin status value
+    // This prevents redundant API calls when multiple components check admin permissions
     shareReplay(1),
   );
 

--- a/src/app/layouts/default-layout/default-layout.component.html
+++ b/src/app/layouts/default-layout/default-layout.component.html
@@ -1,7 +1,13 @@
 <div class="flex h-full min-h-screen flex-col">
   <app-navbar />
   <div class="flex h-full flex-1 flex-col bg-gray-100">
-    <router-outlet />
+    @if (isInitializing()) {
+      <div class="flex h-full flex-1 items-center justify-center">
+        <app-loading-spinner />
+      </div>
+    } @else {
+      <router-outlet />
+    }
   </div>
   <app-footer />
 </div>

--- a/src/app/layouts/default-layout/default-layout.component.ts
+++ b/src/app/layouts/default-layout/default-layout.component.ts
@@ -1,14 +1,21 @@
-import { Component, inject } from '@angular/core';
-import { FooterComponent } from "../footer/footer.component";
-import { NavbarComponent } from "../navbar/navbar.component";
-import { Router, RouterOutlet } from "@angular/router";
+import { Component, inject, signal } from '@angular/core';
+import { FooterComponent } from '../footer/footer.component';
+import { NavbarComponent } from '../navbar/navbar.component';
+import { Router, RouterOutlet } from '@angular/router';
 import { AuthService } from '../../core/services/auth.service';
 import { toObservable } from '@angular/core/rxjs-interop';
-import { filter, take } from 'rxjs/operators';
+import { filter, take, switchMap, tap, map } from 'rxjs/operators';
+import { LoadingSpinnerComponent } from '../../shared/components/loading-spinner/loading-spinner.component';
+import { of } from 'rxjs';
 
 @Component({
   selector: 'app-default-layout',
-  imports: [FooterComponent, NavbarComponent, RouterOutlet],
+  imports: [
+    FooterComponent,
+    NavbarComponent,
+    RouterOutlet,
+    LoadingSpinnerComponent,
+  ],
   templateUrl: './default-layout.component.html',
   styleUrl: './default-layout.component.css',
 })
@@ -16,23 +23,38 @@ export class DefaultLayoutComponent {
   private authService = inject(AuthService);
   private router = inject(Router);
 
+  isInitializing = signal(false);
+
   constructor() {
     if (this.router.url === '/') {
-      toObservable(this.authService.isLoading).pipe(
-        filter(isLoading => !isLoading),
-        take(1)
-      ).subscribe(() => {
-        const isAuthenticated = this.authService.isAuthenticated();
-        const isAdmin = this.authService.isAdmin();
-
-        if (isAuthenticated) {
-          if (isAdmin) {
-            this.router.navigate(['/all-users']);
-          } else {
-            this.router.navigate(['/services']);
-          }
-        }
-      });
+      this.handleRootNavigation();
     }
+  }
+
+  private handleRootNavigation(): void {
+    this.isInitializing.set(true);
+
+    toObservable(this.authService.isLoading)
+      .pipe(
+        filter((isLoading) => !isLoading),
+        take(1),
+        switchMap(() => this.getNavigationRoute()),
+        tap((route) => {
+          this.router.navigate([route]);
+          this.isInitializing.set(false);
+        }),
+      )
+      .subscribe();
+  }
+
+  private getNavigationRoute() {
+    if (!this.authService.isAuthenticated()) {
+      return of('/services');
+    }
+
+    return this.authService.isAdmin$.pipe(
+      take(1),
+      map((isAdmin) => (isAdmin ? '/all-users' : '/services')),
+    );
   }
 }

--- a/src/app/layouts/navbar/navbar.component.html
+++ b/src/app/layouts/navbar/navbar.component.html
@@ -64,27 +64,29 @@
   <div
     class="align-center mt-12 flex justify-center gap-2 font-light text-sky-900 *:rounded-md *:px-6 *:py-2"
   >
-    @for (page of getUserType(); track page) {
-      <a
-        routerLink="{{ page.route }}"
-        routerLinkActive="active"
-        class="relative bg-gray-100 hover:bg-gray-200"
-        [ngClass]="{
-          'bg-sky-900 text-white hover:bg-sky-950': isActive(page.route),
-        }"
-      >
-        @if (
-          (!isAdmin() && page.label === "Pending" && pendingCount() > 0) ||
-          (isAdmin() && page.label === "Requests" && pendingCount() > 0)
-        ) {
-          <span
-            class="absolute -right-2 -top-2 min-h-6 min-w-6 rounded-full bg-red-500 px-2 py-1 text-center text-xs text-white"
-          >
-            {{ pendingCount() }}
-          </span>
-        }
-        {{ page.label }}
-      </a>
+    @if (!adminStatusLoading()) {
+      @for (page of navigationPages(); track page) {
+        <a
+          routerLink="{{ page.route }}"
+          routerLinkActive="active"
+          class="relative bg-gray-100 hover:bg-gray-200"
+          [ngClass]="{
+            'bg-sky-900 text-white hover:bg-sky-950': isActive(page.route),
+          }"
+        >
+          @if (
+            (!isAdmin() && page.label === "Pending" && pendingCount() > 0) ||
+            (isAdmin() && page.label === "Requests" && pendingCount() > 0)
+          ) {
+            <span
+              class="absolute -right-2 -top-2 min-h-6 min-w-6 rounded-full bg-red-500 px-2 py-1 text-center text-xs text-white"
+            >
+              {{ pendingCount() }}
+            </span>
+          }
+          {{ page.label }}
+        </a>
+      }
     }
   </div>
 </nav>

--- a/src/app/layouts/navbar/navbar.component.spec.ts
+++ b/src/app/layouts/navbar/navbar.component.spec.ts
@@ -14,10 +14,11 @@ describe('NavbarComponent', () => {
 
   beforeEach(async () => {
     const apiSpy = jasmine.createSpyObj('ApiService', ['getAllPending']);
-    const authSpy = jasmine.createSpyObj('AuthService', [], {
+    const authSpy = jasmine.createSpyObj('AuthService', ['logout'], {
       isAuthenticated: signal(true),
       user: signal({ name: 'Test User', picture: 'test.jpg' }),
       isAdmin: signal(false),
+      isLoading: signal(false),
     });
     const routerSpy = jasmine.createSpyObj(
       'Router',
@@ -95,19 +96,27 @@ describe('NavbarComponent', () => {
     expect(component.pendingCount()).toBe(0);
   });
 
-  it('should return user pages for non-admin', () => {
-    const pages = component.getUserType();
-    expect(pages).toBe(component.userPages);
+  it('should return user navigation pages for non-admin', () => {
+    const pages = component.navigationPages();
+    expect(pages).toEqual([
+      { label: 'Services', route: '/services' },
+      { label: 'Access', route: '/access' },
+      { label: 'Pending', route: '/pending' },
+    ]);
   });
 
-  it('should return admin pages for admin', () => {
+  it('should return admin navigation pages for admin', () => {
     Object.defineProperty(mockAuthService, 'isAdmin', {
       value: signal(true),
     });
     component.isAdmin = mockAuthService.isAdmin;
 
-    const pages = component.getUserType();
-    expect(pages).toBe(component.adminPages);
+    const pages = component.navigationPages();
+    expect(pages).toEqual([
+      { label: 'All users', route: '/all-users' },
+      { label: 'Revoked', route: '/revoked' },
+      { label: 'Requests', route: '/requests' },
+    ]);
   });
 
   it('should toggle user menu', () => {
@@ -126,11 +135,6 @@ describe('NavbarComponent', () => {
   });
 
   it('should call authService.logout when logout is clicked', () => {
-    const logoutSpy = jasmine.createSpy('logout');
-    Object.defineProperty(mockAuthService, 'logout', {
-      value: logoutSpy,
-    });
-
     mockApiService.getAllPending.and.returnValue(
       of({ pending_services: [], pending_resources: [] }),
     );
@@ -138,6 +142,6 @@ describe('NavbarComponent', () => {
 
     component.logout();
 
-    expect(logoutSpy).toHaveBeenCalled();
+    expect(mockAuthService.logout).toHaveBeenCalled();
   });
 });

--- a/src/app/layouts/navbar/navbar.component.ts
+++ b/src/app/layouts/navbar/navbar.component.ts
@@ -5,13 +5,15 @@ import {
   ViewChild,
   ElementRef,
   signal,
+  computed,
+  effect,
+  DestroyRef,
 } from '@angular/core';
 import { AuthService } from '../../core/services/auth.service';
 import { ApiService } from '../../core/services/api.service';
 import { Router, RouterLink } from '@angular/router';
 import { CommonModule } from '@angular/common';
-import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
-import { filter, switchMap } from 'rxjs/operators';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-navbar',
@@ -25,63 +27,78 @@ export class NavbarComponent {
   private api = inject(ApiService);
   private renderer = inject(Renderer2);
   private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
 
   @ViewChild('menu', { read: ElementRef }) menu!: ElementRef;
   @ViewChild('userMenuButton', { read: ElementRef })
   userMenuButton!: ElementRef;
 
+  // Auth signals
   isAuthenticated = this.authService.isAuthenticated;
   user = this.authService.user;
   isAdmin = this.authService.isAdmin;
+  isLoading = this.authService.isLoading;
 
+  // Component state
   pendingCount = signal(0);
   userMenuOpen = signal(false);
 
-  userPages = [
-    { label: 'Services', route: '/services' },
-    { label: 'Access', route: '/access' },
-    { label: 'Pending', route: '/pending' },
-  ];
+  // Computed properties
+  adminStatusLoading = computed(
+    () => this.isLoading() && this.isAuthenticated(),
+  );
 
-  adminPages = [
-    { label: 'All users', route: '/all-users' },
-    { label: 'Revoked', route: '/revoked' },
-    { label: 'Requests', route: '/requests' },
-  ];
+  navigationPages = computed(() =>
+    this.isAdmin()
+      ? [
+          { label: 'All users', route: '/all-users' },
+          { label: 'Revoked', route: '/revoked' },
+          { label: 'Requests', route: '/requests' },
+        ]
+      : [
+          { label: 'Services', route: '/services' },
+          { label: 'Access', route: '/access' },
+          { label: 'Pending', route: '/pending' },
+        ],
+  );
 
   constructor() {
-    toObservable(this.isAuthenticated)
-      .pipe(
-        takeUntilDestroyed(),
-        filter(Boolean),
-        switchMap(() => this.api.getAllPending()),
-      )
-      .subscribe({
-        next: (pendingData) => {
-          const totalPending =
-            (pendingData?.pending_services?.length || 0) +
-            (pendingData?.pending_resources?.length || 0);
-          this.pendingCount.set(totalPending);
-        },
-        error: (error) => {
-          console.error('Failed to fetch pending count:', error);
-          this.pendingCount.set(0);
-        },
-      });
+    this.setupPendingCountTracking();
+    this.setupClickOutsideMenuHandler();
+  }
 
-    // Close menu on outside click
-    this.renderer.listen('window', 'click', (e: Event) => {
-      if (
-        !this.userMenuButton?.nativeElement.contains(e.target) &&
-        !this.menu?.nativeElement.contains(e.target)
-      ) {
-        this.userMenuOpen.set(false);
+  private setupPendingCountTracking() {
+    effect(() => {
+      if (this.isAuthenticated() && !this.isLoading()) {
+        this.api
+          .getAllPending()
+          .pipe(takeUntilDestroyed(this.destroyRef))
+          .subscribe({
+            next: (pendingData) => {
+              const totalPending =
+                (pendingData?.pending_services?.length || 0) +
+                (pendingData?.pending_resources?.length || 0);
+              this.pendingCount.set(totalPending);
+            },
+            error: (error) => {
+              console.error('Failed to fetch pending count:', error);
+              this.pendingCount.set(0);
+            },
+          });
       }
     });
   }
 
-  getUserType() {
-    return this.isAdmin() ? this.adminPages : this.userPages;
+  private setupClickOutsideMenuHandler() {
+    this.renderer.listen('window', 'click', (e: Event) => {
+      const target = e.target as Element;
+      if (
+        !this.userMenuButton?.nativeElement.contains(target) &&
+        !this.menu?.nativeElement.contains(target)
+      ) {
+        this.userMenuOpen.set(false);
+      }
+    });
   }
 
   toggleUserMenu() {


### PR DESCRIPTION
## Description

[AAI-273](https://biocloud.atlassian.net/jira/software/c/projects/AAI/boards/53?assignee=63f30233526117e1514b222b&selectedIssue=AAI-273): Integrate admin check in the front end

## Changes

- Integrate admin check in the front end
- Refactored default layout component & added in loading spinner during app loading
- Refactored authService, admin guard and navbar code
- Fixed a bug where the user pages show up for a brief second right before the admin pages render when an admin user logs in, which was caused by admin and isLoading states. 
- Updated relevant tests, as well as updating api-service test file to fix deprecated imports

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

## How to Test Manually

<Describe how reviewers can manually test the changes>

## Screenshots for any UI changes

<Paste screenshots or screen recordings here if any updates to UI>


[AAI-273]: https://biocloud.atlassian.net/browse/AAI-273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ