### PR TITLE
AAA-251 remove groups/services from app_metadata, update them to match backend API

### DIFF
--- a/src/app/core/constants/constants.ts
+++ b/src/app/core/constants/constants.ts
@@ -13,6 +13,12 @@ export interface Bundle {
   services: BundleService[];
 }
 
+export type PLATFORM_IDS = 'galaxy' | 'bpa_data_portal';
+export const PLATFORM_NAMES = {
+  galaxy: 'Galaxy Australia',
+  bpa_data_portal: 'Bioplatforms Australia Data Portal',
+};
+
 const bpaBundleService: BundleService = {
   id: 'bpa',
   name: 'Bioplatforms Australia Data Portal Terms and Conditions',

--- a/src/app/core/services/api.service.spec.ts
+++ b/src/app/core/services/api.service.spec.ts
@@ -4,7 +4,12 @@ import {
   provideHttpClientTesting,
   HttpTestingController,
 } from '@angular/common/http/testing';
-import { ApiService } from './api.service';
+import {
+  AllPendingResponse,
+  ApiService,
+  GroupUserResponse,
+  PlatformUserResponse,
+} from './api.service';
 import { environment } from '../../../environments/environment';
 
 describe('ApiService', () => {
@@ -28,74 +33,61 @@ describe('ApiService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should fetch approved services', () => {
-    const mockResponse = {
-      approved_services: [
-        {
-          id: '1',
-          name: 'Test Service',
-          status: 'active',
-          last_updated: '',
-          updated_by: '',
-          resources: [],
-        },
-      ],
-    };
+  it('should fetch approved platforms', () => {
+    const mockResponse: PlatformUserResponse[] = [
+      { platform_id: 'galaxy', approval_status: 'approved' },
+    ];
 
-    service.getApprovedServices().subscribe((response) => {
+    service.getUserApprovedPlatforms().subscribe((response) => {
       expect(response).toEqual(mockResponse);
-      expect(response.approved_services.length).toBe(1);
-      expect(response.approved_services[0].name).toBe('Test Service');
+      expect(response.length).toBe(1);
     });
 
     const req = httpMock.expectOne(
-      `${environment.auth0.backend}/me/services/approved`,
+      `${environment.auth0.backend}/me/platforms/approved`,
     );
     expect(req.request.method).toBe('GET');
     req.flush(mockResponse);
   });
 
-  it('should fetch approved resources', () => {
-    const mockResponse = {
-      approved_resources: [
-        { id: '1', name: 'Test Resource', status: 'active' },
-      ],
-    };
+  it('should fetch approved groups', () => {
+    const mockResponse: GroupUserResponse[] = [
+      {
+        group_name: 'Threatened Species Initiative',
+        group_id: 'tsi',
+        approval_status: 'approved',
+      },
+    ];
 
-    service.getApprovedResources().subscribe((response) => {
+    service.getUserApprovedGroups().subscribe((response) => {
       expect(response).toEqual(mockResponse);
-      expect(response.approved_resources.length).toBe(1);
-      expect(response.approved_resources[0].name).toBe('Test Resource');
+      expect(response.length).toBe(1);
+      expect(response[0].group_name).toBe('Threatened Species Initiative');
     });
 
     const req = httpMock.expectOne(
-      `${environment.auth0.backend}/me/resources/approved`,
+      `${environment.auth0.backend}/me/groups/approved`,
     );
     expect(req.request.method).toBe('GET');
     req.flush(mockResponse);
   });
 
   it('should fetch all pending items', () => {
-    const mockResponse = {
-      pending_services: [
+    const mockResponse: AllPendingResponse = {
+      platforms: [{ platform_id: 'galaxy', approval_status: 'pending' }],
+      groups: [
         {
-          id: '1',
-          name: 'Pending Service',
-          status: 'pending',
-          last_updated: '',
-          updated_by: '',
-          resources: [],
+          group_id: 'tsi',
+          group_name: 'Threatened Species Initiative',
+          approval_status: 'pending',
         },
-      ],
-      pending_resources: [
-        { id: '2', name: 'Pending Resource', status: 'pending' },
       ],
     };
 
-    service.getAllPendingRequests().subscribe((response) => {
+    service.getUserAllPending().subscribe((response) => {
       expect(response).toEqual(mockResponse);
-      expect(response.pending_services.length).toBe(1);
-      expect(response.pending_resources.length).toBe(1);
+      expect(response.platforms.length).toBe(1);
+      expect(response.groups.length).toBe(1);
     });
 
     const req = httpMock.expectOne(
@@ -106,11 +98,11 @@ describe('ApiService', () => {
   });
 
   it('should handle empty responses', () => {
-    const mockResponse = { pending_services: [], pending_resources: [] };
+    const mockResponse: AllPendingResponse = { platforms: [], groups: [] };
 
-    service.getAllPendingRequests().subscribe((response) => {
-      expect(response.pending_services).toEqual([]);
-      expect(response.pending_resources).toEqual([]);
+    service.getUserAllPending().subscribe((response) => {
+      expect(response.platforms).toEqual([]);
+      expect(response.groups).toEqual([]);
     });
 
     const req = httpMock.expectOne(

--- a/src/app/core/services/api.service.ts
+++ b/src/app/core/services/api.service.ts
@@ -3,33 +3,22 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { BiocommonsAuth0User } from './auth.service';
+import { PLATFORM_IDS } from '../constants/constants';
 
-export interface Resource {
-  name: string;
-  status: string;
-  id: string;
+export interface PlatformUserResponse {
+  platform_id: PLATFORM_IDS;
+  approval_status: string;
 }
 
-export interface Service {
-  name: string;
-  id: string;
-  status: string;
-  last_updated: string;
-  updated_by: string;
-  resources: Resource[];
+export interface GroupUserResponse {
+  group_id: string;
+  approval_status: string;
+  group_name: string;
 }
 
-export interface Pending {
-  pending_services: Service[];
-  pending_resources: Resource[];
-}
-
-export interface ApprovedServicesResponse {
-  approved_services: Service[];
-}
-
-export interface ApprovedResourcesResponse {
-  approved_resources: Resource[];
+export interface AllPendingResponse {
+  platforms: PlatformUserResponse[];
+  groups: GroupUserResponse[];
 }
 
 export interface FilterOption {
@@ -40,13 +29,14 @@ export interface FilterOption {
 export interface BiocommonsUserResponse {
   id: string;
   email: string;
+  email_verified: boolean;
   username: string;
   created_at: string;
 }
 
 export interface PlatformMembership {
   id: string;
-  platform_id: string;
+  platform_id: PLATFORM_IDS;
   user_id: string;
   approval_status: string;
   updated_by: string;
@@ -71,20 +61,20 @@ export interface BiocommonsUserDetails extends BiocommonsAuth0User {
 export class ApiService {
   private http = inject(HttpClient);
 
-  getApprovedServices(): Observable<ApprovedServicesResponse> {
-    return this.http.get<ApprovedServicesResponse>(
-      `${environment.auth0.backend}/me/services/approved`,
+  getUserApprovedPlatforms(): Observable<PlatformUserResponse[]> {
+    return this.http.get<PlatformUserResponse[]>(
+      `${environment.auth0.backend}/me/platforms/approved`,
     );
   }
 
-  getApprovedResources(): Observable<ApprovedResourcesResponse> {
-    return this.http.get<ApprovedResourcesResponse>(
-      `${environment.auth0.backend}/me/resources/approved`,
+  getUserApprovedGroups(): Observable<GroupUserResponse[]> {
+    return this.http.get<GroupUserResponse[]>(
+      `${environment.auth0.backend}/me/groups/approved`,
     );
   }
 
-  getAllPendingRequests(): Observable<Pending> {
-    return this.http.get<Pending>(
+  getUserAllPending(): Observable<AllPendingResponse> {
+    return this.http.get<AllPendingResponse>(
       `${environment.auth0.backend}/me/all/pending`,
     );
   }
@@ -119,26 +109,32 @@ export class ApiService {
     );
   }
 
-  getUnverifiedUsers(
+  getAdminUnverifiedUsers(
     page = 1,
     pageSize = 20,
-  ): Observable<BiocommonsAuth0User[]> {
+  ): Observable<BiocommonsUserResponse[]> {
     const params = `?page=${page}&page_size=${pageSize}`;
-    return this.http.get<BiocommonsAuth0User[]>(
+    return this.http.get<BiocommonsUserResponse[]>(
       `${environment.auth0.backend}/admin/users/unverified${params}`,
     );
   }
 
-  getPendingUsers(page = 1, pageSize = 20): Observable<BiocommonsAuth0User[]> {
+  getAdminPendingUsers(
+    page = 1,
+    pageSize = 20,
+  ): Observable<BiocommonsUserResponse[]> {
     const params = `?page=${page}&page_size=${pageSize}`;
-    return this.http.get<BiocommonsAuth0User[]>(
+    return this.http.get<BiocommonsUserResponse[]>(
       `${environment.auth0.backend}/admin/users/pending${params}`,
     );
   }
 
-  getRevokedUsers(page = 1, pageSize = 20): Observable<BiocommonsAuth0User[]> {
+  getAdminRevokedUsers(
+    page = 1,
+    pageSize = 20,
+  ): Observable<BiocommonsUserResponse[]> {
     const params = `?page=${page}&page_size=${pageSize}`;
-    return this.http.get<BiocommonsAuth0User[]>(
+    return this.http.get<BiocommonsUserResponse[]>(
       `${environment.auth0.backend}/admin/users/revoked${params}`,
     );
   }

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -8,26 +8,6 @@ import { environment } from '../../../environments/environment';
 
 export type Status = 'approved' | 'revoked' | 'pending';
 
-export interface Resource {
-  name: string;
-  status: Status;
-  id: string;
-}
-
-export interface Service {
-  name: string;
-  id: string;
-  status: Status;
-  last_updated: string;
-  updated_by: string;
-  resources: Resource[];
-}
-
-export interface Group {
-  name: string;
-  id: string;
-}
-
 export interface Identity {
   connection: string;
   provider: string;
@@ -46,8 +26,6 @@ export interface BiocommonsUserMetadata {
 }
 
 export interface BiocommonsAppMetadata {
-  groups: Group[];
-  services: Service[];
   registration_from?: 'biocommons' | 'galaxy' | 'bpa';
 }
 

--- a/src/app/layouts/default-layout/default-layout.component.spec.ts
+++ b/src/app/layouts/default-layout/default-layout.component.spec.ts
@@ -44,8 +44,8 @@ describe('DefaultLayoutComponent', () => {
     routerSpy.serializeUrl.and.returnValue('/mocked-url');
 
     const apiSpy = jasmine.createSpyObj('ApiService', [
-      'getAllPendingRequests',
-      'getPendingUsers',
+      'getUserAllPending',
+      'getAdminPendingUsers',
     ]);
 
     const activatedRouteSpy = jasmine.createSpyObj('ActivatedRoute', [], {
@@ -94,10 +94,10 @@ describe('DefaultLayoutComponent', () => {
     mockRouter = TestBed.inject(Router) as jasmine.SpyObj<Router>;
     mockApiService = TestBed.inject(ApiService) as jasmine.SpyObj<ApiService>;
 
-    mockApiService.getAllPendingRequests.and.returnValue(
-      of({ pending_services: [], pending_resources: [] }),
+    mockApiService.getUserAllPending.and.returnValue(
+      of({ platforms: [], groups: [] }),
     );
-    mockApiService.getPendingUsers.and.returnValue(of([]));
+    mockApiService.getAdminPendingUsers.and.returnValue(of([]));
   });
 
   it('should create', () => {
@@ -113,10 +113,10 @@ describe('DefaultLayoutComponent', () => {
     mockRouter = TestBed.inject(Router) as jasmine.SpyObj<Router>;
     mockApiService = TestBed.inject(ApiService) as jasmine.SpyObj<ApiService>;
 
-    mockApiService.getAllPendingRequests.and.returnValue(
-      of({ pending_services: [], pending_resources: [] }),
+    mockApiService.getUserAllPending.and.returnValue(
+      of({ platforms: [], groups: [] }),
     );
-    mockApiService.getPendingUsers.and.returnValue(of([]));
+    mockApiService.getAdminPendingUsers.and.returnValue(of([]));
 
     fixture.detectChanges();
 
@@ -137,10 +137,10 @@ describe('DefaultLayoutComponent', () => {
     mockRouter = TestBed.inject(Router) as jasmine.SpyObj<Router>;
     mockApiService = TestBed.inject(ApiService) as jasmine.SpyObj<ApiService>;
 
-    mockApiService.getAllPendingRequests.and.returnValue(
-      of({ pending_services: [], pending_resources: [] }),
+    mockApiService.getUserAllPending.and.returnValue(
+      of({ platforms: [], groups: [] }),
     );
-    mockApiService.getPendingUsers.and.returnValue(of([]));
+    mockApiService.getAdminPendingUsers.and.returnValue(of([]));
 
     fixture.detectChanges();
 
@@ -161,10 +161,10 @@ describe('DefaultLayoutComponent', () => {
     mockRouter = TestBed.inject(Router) as jasmine.SpyObj<Router>;
     mockApiService = TestBed.inject(ApiService) as jasmine.SpyObj<ApiService>;
 
-    mockApiService.getAllPendingRequests.and.returnValue(
-      of({ pending_services: [], pending_resources: [] }),
+    mockApiService.getUserAllPending.and.returnValue(
+      of({ platforms: [], groups: [] }),
     );
-    mockApiService.getPendingUsers.and.returnValue(of([]));
+    mockApiService.getAdminPendingUsers.and.returnValue(of([]));
 
     fixture.detectChanges();
 
@@ -185,10 +185,10 @@ describe('DefaultLayoutComponent', () => {
     mockRouter = TestBed.inject(Router) as jasmine.SpyObj<Router>;
     mockApiService = TestBed.inject(ApiService) as jasmine.SpyObj<ApiService>;
 
-    mockApiService.getAllPendingRequests.and.returnValue(
-      of({ pending_services: [], pending_resources: [] }),
+    mockApiService.getUserAllPending.and.returnValue(
+      of({ platforms: [], groups: [] }),
     );
-    mockApiService.getPendingUsers.and.returnValue(of([]));
+    mockApiService.getAdminPendingUsers.and.returnValue(of([]));
 
     fixture.detectChanges();
 

--- a/src/app/layouts/navbar/navbar.component.spec.ts
+++ b/src/app/layouts/navbar/navbar.component.spec.ts
@@ -3,7 +3,10 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { of, throwError, EMPTY } from 'rxjs';
 import { signal } from '@angular/core';
 import { NavbarComponent } from './navbar.component';
-import { ApiService } from '../../core/services/api.service';
+import {
+  AllPendingResponse,
+  ApiService,
+} from '../../core/services/api.service';
 import { AuthService } from '../../core/services/auth.service';
 
 describe('NavbarComponent', () => {
@@ -13,9 +16,7 @@ describe('NavbarComponent', () => {
   let mockAuthService: jasmine.SpyObj<AuthService>;
 
   beforeEach(async () => {
-    const apiSpy = jasmine.createSpyObj('ApiService', [
-      'getAllPendingRequests',
-    ]);
+    const apiSpy = jasmine.createSpyObj('ApiService', ['getUserAllPending']);
     const authSpy = jasmine.createSpyObj('AuthService', ['logout'], {
       isAuthenticated: signal(true),
       user: signal({ name: 'Test User', picture: 'test.jpg' }),
@@ -60,28 +61,21 @@ describe('NavbarComponent', () => {
   });
 
   it('should create', () => {
-    mockApiService.getAllPendingRequests.and.returnValue(
-      of({ pending_services: [], pending_resources: [] }),
+    mockApiService.getUserAllPending.and.returnValue(
+      of({ platforms: [], groups: [] }),
     );
     fixture.detectChanges();
     expect(component).toBeTruthy();
   });
 
   it('should calculate pending count correctly', () => {
-    const mockPending = {
-      pending_services: [
-        {
-          id: '1',
-          name: 'Service',
-          status: 'pending',
-          last_updated: '',
-          updated_by: '',
-          resources: [],
-        },
+    const mockPending: AllPendingResponse = {
+      platforms: [{ platform_id: 'galaxy', approval_status: 'pending' }],
+      groups: [
+        { group_id: 'tsi', group_name: 'TSI', approval_status: 'pending' },
       ],
-      pending_resources: [{ id: '2', name: 'Resource', status: 'pending' }],
     };
-    mockApiService.getAllPendingRequests.and.returnValue(of(mockPending));
+    mockApiService.getUserAllPending.and.returnValue(of(mockPending));
 
     fixture.detectChanges();
 
@@ -89,7 +83,7 @@ describe('NavbarComponent', () => {
   });
 
   it('should handle API error gracefully', () => {
-    mockApiService.getAllPendingRequests.and.returnValue(
+    mockApiService.getUserAllPending.and.returnValue(
       throwError(() => new Error('API Error')),
     );
 
@@ -138,8 +132,8 @@ describe('NavbarComponent', () => {
   });
 
   it('should call authService.logout when logout is clicked', () => {
-    mockApiService.getAllPendingRequests.and.returnValue(
-      of({ pending_services: [], pending_resources: [] }),
+    mockApiService.getUserAllPending.and.returnValue(
+      of({ platforms: [], groups: [] }),
     );
     fixture.detectChanges();
 

--- a/src/app/layouts/navbar/navbar.component.ts
+++ b/src/app/layouts/navbar/navbar.component.ts
@@ -74,7 +74,7 @@ export class NavbarComponent {
         if (this.isAdmin()) {
           // Admin: Get pending users
           this.api
-            .getPendingUsers()
+            .getAdminPendingUsers()
             .pipe(takeUntilDestroyed(this.destroyRef))
             .subscribe({
               next: (pendingUsers) => {
@@ -88,13 +88,13 @@ export class NavbarComponent {
         } else {
           // Non-admin: Get pending requests (services and resources)
           this.api
-            .getAllPendingRequests()
+            .getUserAllPending()
             .pipe(takeUntilDestroyed(this.destroyRef))
             .subscribe({
               next: (pendingData) => {
                 const totalPending =
-                  (pendingData?.pending_services?.length || 0) +
-                  (pendingData?.pending_resources?.length || 0);
+                  (pendingData?.platforms.length || 0) +
+                  (pendingData?.groups?.length || 0);
                 this.pendingCount.set(totalPending);
               },
               error: (error) => {

--- a/src/app/layouts/navbar/navbar.component.ts
+++ b/src/app/layouts/navbar/navbar.component.ts
@@ -86,7 +86,7 @@ export class NavbarComponent {
               },
             });
         } else {
-          // Non-admin: Get pending requests (services and resources)
+          // Non-admin: Get pending requests (platforms and groups)
           this.api
             .getUserAllPending()
             .pipe(takeUntilDestroyed(this.destroyRef))

--- a/src/app/layouts/navbar/navbar.component.ts
+++ b/src/app/layouts/navbar/navbar.component.ts
@@ -93,7 +93,7 @@ export class NavbarComponent {
             .subscribe({
               next: (pendingData) => {
                 const totalPending =
-                  (pendingData?.platforms.length || 0) +
+                  (pendingData?.platforms?.length || 0) +
                   (pendingData?.groups?.length || 0);
                 this.pendingCount.set(totalPending);
               },

--- a/src/app/pages/admin/list-unverified-users/list-unverified-users.component.html
+++ b/src/app/pages/admin/list-unverified-users/list-unverified-users.component.html
@@ -17,7 +17,7 @@
             No users found
           </div>
         } @else {
-          @for (user of users; track user.user_id) {
+          @for (user of users; track user.id) {
             <div
               role="button"
               tabindex="0"

--- a/src/app/pages/admin/list-unverified-users/list-unverified-users.component.spec.ts
+++ b/src/app/pages/admin/list-unverified-users/list-unverified-users.component.spec.ts
@@ -4,44 +4,36 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { of, throwError } from 'rxjs';
 
 import { ListUnverifiedUsersComponent } from './list-unverified-users.component';
-import { ApiService } from '../../../core/services/api.service';
-import { BiocommonsAuth0User } from '../../../core/services/auth.service';
+import {
+  ApiService,
+  BiocommonsUserResponse,
+} from '../../../core/services/api.service';
 
 describe('ListUnverifiedUsersComponent', () => {
   let component: ListUnverifiedUsersComponent;
   let fixture: ComponentFixture<ListUnverifiedUsersComponent>;
   let apiService: jasmine.SpyObj<ApiService>;
 
-  const mockUsers: BiocommonsAuth0User[] = [
+  const mockUsers: BiocommonsUserResponse[] = [
     {
+      id: '1',
       created_at: '2024-01-01T00:00:00.000Z',
+      username: 'unverified1',
       email: 'unverified1@test.com',
       email_verified: false,
-      username: 'unverified1',
-      identities: [],
-      name: 'Unverified User 1',
-      nickname: 'unverified1',
-      picture: '',
-      updated_at: '2024-01-01T00:00:00.000Z',
-      user_id: '1',
-    } as BiocommonsAuth0User,
+    },
     {
-      created_at: '2024-01-02T00:00:00.000Z',
-      email: 'unverified2@test.com',
-      email_verified: false,
+      id: '2',
+      created_at: '2024-01-01T00:00:00.000Z',
       username: 'unverified2',
-      identities: [],
-      name: 'Unverified User 2',
-      nickname: 'unverified2',
-      picture: '',
-      updated_at: '2024-01-02T00:00:00.000Z',
-      user_id: '2',
-    } as BiocommonsAuth0User,
+      email: 'unverified2@example.com',
+      email_verified: false,
+    },
   ];
 
   beforeEach(async () => {
     const apiServiceSpy = jasmine.createSpyObj('ApiService', [
-      'getUnverifiedUsers',
+      'getAdminUnverifiedUsers',
     ]);
 
     await TestBed.configureTestingModule({
@@ -59,36 +51,36 @@ describe('ListUnverifiedUsersComponent', () => {
   });
 
   it('should create', () => {
-    apiService.getUnverifiedUsers.and.returnValue(of(mockUsers));
+    apiService.getAdminUnverifiedUsers.and.returnValue(of(mockUsers));
     fixture.detectChanges();
     expect(component).toBeTruthy();
   });
 
   it('should load unverified users on init', () => {
-    apiService.getUnverifiedUsers.and.returnValue(of(mockUsers));
+    apiService.getAdminUnverifiedUsers.and.returnValue(of(mockUsers));
 
     component.ngOnInit();
 
-    expect(apiService.getUnverifiedUsers).toHaveBeenCalledWith(1, 50);
+    expect(apiService.getAdminUnverifiedUsers).toHaveBeenCalledWith(1, 50);
     expect(component.users).toEqual(mockUsers);
     expect(component.loading).toBe(false);
   });
 
   it('should handle loading state', () => {
-    apiService.getUnverifiedUsers.and.returnValue(of(mockUsers));
+    apiService.getAdminUnverifiedUsers.and.returnValue(of(mockUsers));
 
     expect(component.loading).toBe(false); // Initially false
 
     component.ngOnInit();
 
-    expect(apiService.getUnverifiedUsers).toHaveBeenCalledWith(1, 50);
+    expect(apiService.getAdminUnverifiedUsers).toHaveBeenCalledWith(1, 50);
     expect(component.users).toEqual(mockUsers);
     expect(component.loading).toBe(false); // Set to false after successful response
   });
 
   it('should handle error when loading users', () => {
     const consoleErrorSpy = spyOn(console, 'error');
-    apiService.getUnverifiedUsers.and.returnValue(
+    apiService.getAdminUnverifiedUsers.and.returnValue(
       throwError(() => new Error('Test error')),
     );
 

--- a/src/app/pages/admin/list-unverified-users/list-unverified-users.component.ts
+++ b/src/app/pages/admin/list-unverified-users/list-unverified-users.component.ts
@@ -1,6 +1,5 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { LoadingSpinnerComponent } from '../../../shared/components/loading-spinner/loading-spinner.component';
-import { BiocommonsAuth0User } from '../../../core/services/auth.service';
 import {
   ApiService,
   BiocommonsUserResponse,

--- a/src/app/pages/admin/list-unverified-users/list-unverified-users.component.ts
+++ b/src/app/pages/admin/list-unverified-users/list-unverified-users.component.ts
@@ -1,7 +1,10 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { LoadingSpinnerComponent } from '../../../shared/components/loading-spinner/loading-spinner.component';
 import { BiocommonsAuth0User } from '../../../core/services/auth.service';
-import { ApiService } from '../../../core/services/api.service';
+import {
+  ApiService,
+  BiocommonsUserResponse,
+} from '../../../core/services/api.service';
 
 @Component({
   selector: 'app-list-unverified-users',
@@ -13,11 +16,11 @@ export class ListUnverifiedUsersComponent implements OnInit {
   private apiService = inject(ApiService);
 
   loading = false;
-  users: BiocommonsAuth0User[] = [];
+  users: BiocommonsUserResponse[] = [];
 
   ngOnInit(): void {
     this.loading = true;
-    this.apiService.getUnverifiedUsers(1, 50).subscribe({
+    this.apiService.getAdminUnverifiedUsers(1, 50).subscribe({
       next: (users) => {
         this.users = users;
         this.loading = false;

--- a/src/app/pages/admin/list-users/list-users.component.spec.ts
+++ b/src/app/pages/admin/list-users/list-users.component.spec.ts
@@ -26,11 +26,13 @@ describe('ListUsersComponent', () => {
       id: '1',
       email: 'user1@example.com',
       username: 'user1',
+      email_verified: true,
       created_at: '2023-01-01T00:00:00Z',
     },
     {
       id: '2',
       email: 'user2@example.com',
+      email_verified: true,
       username: 'user2',
       created_at: '2023-01-02T00:00:00Z',
     },

--- a/src/app/pages/admin/requests/requests.component.html
+++ b/src/app/pages/admin/requests/requests.component.html
@@ -17,7 +17,7 @@
             No users found
           </div>
         } @else {
-          @for (user of users; track user.user_id) {
+          @for (user of users; track user.id) {
             <div
               role="button"
               tabindex="0"

--- a/src/app/pages/admin/requests/requests.component.spec.ts
+++ b/src/app/pages/admin/requests/requests.component.spec.ts
@@ -4,44 +4,36 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { of, throwError } from 'rxjs';
 
 import { RequestsComponent } from './requests.component';
-import { ApiService } from '../../../core/services/api.service';
-import { BiocommonsAuth0User } from '../../../core/services/auth.service';
+import {
+  ApiService,
+  BiocommonsUserResponse,
+} from '../../../core/services/api.service';
 
 describe('RequestsComponent', () => {
   let component: RequestsComponent;
   let fixture: ComponentFixture<RequestsComponent>;
   let apiService: jasmine.SpyObj<ApiService>;
 
-  const mockUsers: BiocommonsAuth0User[] = [
+  const mockUsers: BiocommonsUserResponse[] = [
     {
-      created_at: '2024-01-01T00:00:00.000Z',
-      email: 'user1@test.com',
-      email_verified: true,
+      id: '1',
+      email: 'user1@example.com',
       username: 'user1',
-      identities: [],
-      name: 'User 1',
-      nickname: 'user1',
-      picture: '',
-      updated_at: '2024-01-01T00:00:00.000Z',
-      user_id: '1',
-    } as BiocommonsAuth0User,
+      email_verified: true,
+      created_at: '2023-01-01T00:00:00Z',
+    },
     {
-      created_at: '2024-01-02T00:00:00.000Z',
-      email: 'user2@test.com',
+      id: '2',
+      email: 'user2@example.com',
       email_verified: true,
       username: 'user2',
-      identities: [],
-      name: 'User 2',
-      nickname: 'user2',
-      picture: '',
-      updated_at: '2024-01-02T00:00:00.000Z',
-      user_id: '2',
-    } as BiocommonsAuth0User,
+      created_at: '2023-01-02T00:00:00Z',
+    },
   ];
 
   beforeEach(async () => {
     const apiServiceSpy = jasmine.createSpyObj('ApiService', [
-      'getPendingUsers',
+      'getAdminPendingUsers',
     ]);
 
     await TestBed.configureTestingModule({
@@ -59,36 +51,36 @@ describe('RequestsComponent', () => {
   });
 
   it('should create', () => {
-    apiService.getPendingUsers.and.returnValue(of(mockUsers));
+    apiService.getAdminPendingUsers.and.returnValue(of(mockUsers));
     fixture.detectChanges();
     expect(component).toBeTruthy();
   });
 
   it('should load pending users on init', () => {
-    apiService.getPendingUsers.and.returnValue(of(mockUsers));
+    apiService.getAdminPendingUsers.and.returnValue(of(mockUsers));
 
     component.ngOnInit();
 
-    expect(apiService.getPendingUsers).toHaveBeenCalledWith(1, 50);
+    expect(apiService.getAdminPendingUsers).toHaveBeenCalledWith(1, 50);
     expect(component.users).toEqual(mockUsers);
     expect(component.loading).toBe(false);
   });
 
   it('should handle loading state', () => {
-    apiService.getPendingUsers.and.returnValue(of(mockUsers));
+    apiService.getAdminPendingUsers.and.returnValue(of(mockUsers));
 
     expect(component.loading).toBe(false); // Initially false
 
     component.ngOnInit();
 
-    expect(apiService.getPendingUsers).toHaveBeenCalledWith(1, 50);
+    expect(apiService.getAdminPendingUsers).toHaveBeenCalledWith(1, 50);
     expect(component.users).toEqual(mockUsers);
     expect(component.loading).toBe(false); // Set to false after successful response
   });
 
   it('should handle error when loading users', () => {
     const consoleErrorSpy = spyOn(console, 'error');
-    apiService.getPendingUsers.and.returnValue(
+    apiService.getAdminPendingUsers.and.returnValue(
       throwError(() => new Error('Test error')),
     );
 

--- a/src/app/pages/admin/requests/requests.component.ts
+++ b/src/app/pages/admin/requests/requests.component.ts
@@ -4,7 +4,6 @@ import {
   ApiService,
   BiocommonsUserResponse,
 } from '../../../core/services/api.service';
-import { BiocommonsAuth0User } from '../../../core/services/auth.service';
 
 @Component({
   selector: 'app-requests',

--- a/src/app/pages/admin/requests/requests.component.ts
+++ b/src/app/pages/admin/requests/requests.component.ts
@@ -1,6 +1,9 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { LoadingSpinnerComponent } from '../../../shared/components/loading-spinner/loading-spinner.component';
-import { ApiService } from '../../../core/services/api.service';
+import {
+  ApiService,
+  BiocommonsUserResponse,
+} from '../../../core/services/api.service';
 import { BiocommonsAuth0User } from '../../../core/services/auth.service';
 
 @Component({
@@ -13,11 +16,11 @@ export class RequestsComponent implements OnInit {
   private apiService = inject(ApiService);
 
   loading = false;
-  users: BiocommonsAuth0User[] = [];
+  users: BiocommonsUserResponse[] = [];
 
   ngOnInit(): void {
     this.loading = true;
-    this.apiService.getPendingUsers(1, 50).subscribe({
+    this.apiService.getAdminPendingUsers(1, 50).subscribe({
       next: (users) => {
         this.users = users;
         this.loading = false;

--- a/src/app/pages/admin/revoked/revoked.component.html
+++ b/src/app/pages/admin/revoked/revoked.component.html
@@ -17,7 +17,7 @@
             No users found
           </div>
         } @else {
-          @for (user of users; track user.user_id) {
+          @for (user of users; track user.id) {
             <div
               role="button"
               tabindex="0"

--- a/src/app/pages/admin/revoked/revoked.component.spec.ts
+++ b/src/app/pages/admin/revoked/revoked.component.spec.ts
@@ -4,44 +4,36 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { of, throwError } from 'rxjs';
 
 import { RevokedComponent } from './revoked.component';
-import { ApiService } from '../../../core/services/api.service';
-import { BiocommonsAuth0User } from '../../../core/services/auth.service';
+import {
+  ApiService,
+  BiocommonsUserResponse,
+} from '../../../core/services/api.service';
 
 describe('RevokedComponent', () => {
   let component: RevokedComponent;
   let fixture: ComponentFixture<RevokedComponent>;
   let apiService: jasmine.SpyObj<ApiService>;
 
-  const mockUsers: BiocommonsAuth0User[] = [
+  const mockUsers: BiocommonsUserResponse[] = [
     {
-      created_at: '2024-01-01T00:00:00.000Z',
-      email: 'revoked1@test.com',
-      username: 'revoked1',
+      id: '1',
+      email: 'user1@example.com',
+      username: 'user1',
       email_verified: true,
-      identities: [],
-      name: 'Revoked User 1',
-      nickname: 'revoked1',
-      picture: '',
-      updated_at: '2024-01-01T00:00:00.000Z',
-      user_id: '1',
-    } as BiocommonsAuth0User,
+      created_at: '2023-01-01T00:00:00Z',
+    },
     {
-      created_at: '2024-01-02T00:00:00.000Z',
-      email: 'revoked2@test.com',
+      id: '2',
+      email: 'user2@example.com',
       email_verified: true,
-      username: 'revoked2',
-      identities: [],
-      name: 'Revoked User 2',
-      nickname: 'revoked2',
-      picture: '',
-      updated_at: '2024-01-02T00:00:00.000Z',
-      user_id: '2',
-    } as BiocommonsAuth0User,
+      username: 'user2',
+      created_at: '2023-01-02T00:00:00Z',
+    },
   ];
 
   beforeEach(async () => {
     const apiServiceSpy = jasmine.createSpyObj('ApiService', [
-      'getRevokedUsers',
+      'getAdminRevokedUsers',
     ]);
 
     await TestBed.configureTestingModule({
@@ -59,36 +51,36 @@ describe('RevokedComponent', () => {
   });
 
   it('should create', () => {
-    apiService.getRevokedUsers.and.returnValue(of(mockUsers));
+    apiService.getAdminRevokedUsers.and.returnValue(of(mockUsers));
     fixture.detectChanges();
     expect(component).toBeTruthy();
   });
 
   it('should load revoked users on init', () => {
-    apiService.getRevokedUsers.and.returnValue(of(mockUsers));
+    apiService.getAdminRevokedUsers.and.returnValue(of(mockUsers));
 
     component.ngOnInit();
 
-    expect(apiService.getRevokedUsers).toHaveBeenCalledWith(1, 50);
+    expect(apiService.getAdminRevokedUsers).toHaveBeenCalledWith(1, 50);
     expect(component.users).toEqual(mockUsers);
     expect(component.loading).toBe(false);
   });
 
   it('should handle loading state', () => {
-    apiService.getRevokedUsers.and.returnValue(of(mockUsers));
+    apiService.getAdminRevokedUsers.and.returnValue(of(mockUsers));
 
-    expect(component.loading).toBe(false); // Initially false
+    expect(component.loading).toBe(true);
 
     component.ngOnInit();
 
-    expect(apiService.getRevokedUsers).toHaveBeenCalledWith(1, 50);
+    expect(apiService.getAdminRevokedUsers).toHaveBeenCalledWith(1, 50);
     expect(component.users).toEqual(mockUsers);
     expect(component.loading).toBe(false); // Set to false after successful response
   });
 
   it('should handle error when loading users', () => {
     const consoleErrorSpy = spyOn(console, 'error');
-    apiService.getRevokedUsers.and.returnValue(
+    apiService.getAdminRevokedUsers.and.returnValue(
       throwError(() => new Error('Test error')),
     );
 

--- a/src/app/pages/admin/revoked/revoked.component.ts
+++ b/src/app/pages/admin/revoked/revoked.component.ts
@@ -1,6 +1,9 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { LoadingSpinnerComponent } from '../../../shared/components/loading-spinner/loading-spinner.component';
-import { ApiService } from '../../../core/services/api.service';
+import {
+  ApiService,
+  BiocommonsUserResponse,
+} from '../../../core/services/api.service';
 import { BiocommonsAuth0User } from '../../../core/services/auth.service';
 
 @Component({
@@ -12,12 +15,11 @@ import { BiocommonsAuth0User } from '../../../core/services/auth.service';
 export class RevokedComponent implements OnInit {
   private apiService = inject(ApiService);
 
-  loading = false;
-  users: BiocommonsAuth0User[] = [];
+  loading = true;
+  users: BiocommonsUserResponse[] = [];
 
   ngOnInit(): void {
-    this.loading = true;
-    this.apiService.getRevokedUsers(1, 50).subscribe({
+    this.apiService.getAdminRevokedUsers(1, 50).subscribe({
       next: (users) => {
         this.users = users;
         this.loading = false;

--- a/src/app/pages/admin/revoked/revoked.component.ts
+++ b/src/app/pages/admin/revoked/revoked.component.ts
@@ -4,7 +4,6 @@ import {
   ApiService,
   BiocommonsUserResponse,
 } from '../../../core/services/api.service';
-import { BiocommonsAuth0User } from '../../../core/services/auth.service';
 
 @Component({
   selector: 'app-revoked',

--- a/src/app/pages/user/access/access.component.html
+++ b/src/app/pages/user/access/access.component.html
@@ -5,13 +5,13 @@
       <app-loading-spinner />
     </div>
   } @else {
-    @if (approvedResources.length) {
+    @if (approvedGroups.length) {
       <div class="flex flex-col gap-6 p-6 font-light lg:px-48">
-        @for (resource of approvedResources; track resource.id) {
+        @for (group of approvedGroups; track group.group_id) {
           <div
             class="flex items-center justify-between gap-6 rounded-md bg-white p-4"
           >
-            <div class="text-sky-900">{{ resource.name }}</div>
+            <div class="text-sky-900">{{ group.group_name }}</div>
             <div class="rounded-full bg-lime-600 px-4 py-2 text-sm text-white">
               Active
             </div>

--- a/src/app/pages/user/access/access.component.spec.ts
+++ b/src/app/pages/user/access/access.component.spec.ts
@@ -14,7 +14,9 @@ describe('AccessComponent', () => {
   let mockApiService: jasmine.SpyObj<ApiService>;
 
   beforeEach(async () => {
-    const apiSpy = jasmine.createSpyObj('ApiService', ['getApprovedResources']);
+    const apiSpy = jasmine.createSpyObj('ApiService', [
+      'getUserApprovedGroups',
+    ]);
     const authSpy = jasmine.createSpyObj('AuthService', [], {
       isAuthenticated: signal(true),
     });
@@ -36,30 +38,30 @@ describe('AccessComponent', () => {
   });
 
   it('should create', () => {
-    mockApiService.getApprovedResources.and.returnValue(
-      of({ approved_resources: [] }),
-    );
+    mockApiService.getUserApprovedGroups.and.returnValue(of([]));
     fixture.detectChanges();
     expect(component).toBeTruthy();
   });
 
-  it('should load approved resources successfully', () => {
-    const mockResources = [
-      { id: '1', name: 'Test Resource', status: 'active' },
+  it('should load approved groups successfully', () => {
+    const mockGroups = [
+      {
+        group_id: 'tsi',
+        group_name: 'Threatened Species Initiative',
+        approval_status: 'approved',
+      },
     ];
-    mockApiService.getApprovedResources.and.returnValue(
-      of({ approved_resources: mockResources }),
-    );
+    mockApiService.getUserApprovedGroups.and.returnValue(of(mockGroups));
 
     fixture.detectChanges();
 
-    expect(component.approvedResources).toEqual(mockResources);
+    expect(component.approvedGroups).toEqual(mockGroups);
     expect(component.loading()).toBe(false);
     expect(component.error()).toBeNull();
   });
 
   it('should handle error when loading resources fails', () => {
-    mockApiService.getApprovedResources.and.returnValue(
+    mockApiService.getUserApprovedGroups.and.returnValue(
       throwError(() => new Error('API Error')),
     );
 
@@ -70,9 +72,7 @@ describe('AccessComponent', () => {
   });
 
   it('should display no access message when empty', () => {
-    mockApiService.getApprovedResources.and.returnValue(
-      of({ approved_resources: [] }),
-    );
+    mockApiService.getUserApprovedGroups.and.returnValue(of([]));
     fixture.detectChanges();
 
     const compiled = fixture.nativeElement as HTMLElement;
@@ -80,16 +80,18 @@ describe('AccessComponent', () => {
   });
 
   it('should display resources when available', () => {
-    const mockResources = [
-      { id: '1', name: 'Test Resource', status: 'active' },
+    const mockGroups = [
+      {
+        group_id: 'tsi',
+        group_name: 'Threatened Species Initiative',
+        approval_status: 'approved',
+      },
     ];
-    mockApiService.getApprovedResources.and.returnValue(
-      of({ approved_resources: mockResources }),
-    );
+    mockApiService.getUserApprovedGroups.and.returnValue(of(mockGroups));
 
     fixture.detectChanges();
 
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.textContent).toContain('Test Resource');
+    expect(compiled.textContent).toContain('Threatened Species Initiative');
   });
 });

--- a/src/app/pages/user/access/access.component.ts
+++ b/src/app/pages/user/access/access.component.ts
@@ -1,5 +1,8 @@
 import { Component, inject, signal } from '@angular/core';
-import { ApiService, Resource } from '../../../core/services/api.service';
+import {
+  ApiService,
+  GroupUserResponse,
+} from '../../../core/services/api.service';
 import { AuthService } from '../../../core/services/auth.service';
 import { LoadingSpinnerComponent } from '../../../shared/components/loading-spinner/loading-spinner.component';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -14,7 +17,7 @@ import { RouterModule } from '@angular/router';
   styleUrl: './access.component.css',
 })
 export class AccessComponent {
-  approvedResources: Resource[] = [];
+  approvedGroups: GroupUserResponse[] = [];
   loading = signal(true);
   error = signal<string | null>(null);
 
@@ -26,11 +29,11 @@ export class AccessComponent {
       .pipe(
         takeUntilDestroyed(),
         filter((isAuthenticated) => isAuthenticated),
-        switchMap(() => this.api.getApprovedResources()),
+        switchMap(() => this.api.getUserApprovedGroups()),
       )
       .subscribe({
         next: (res) => {
-          this.approvedResources = res.approved_resources || [];
+          this.approvedGroups = res || [];
           this.error.set(null);
           this.loading.set(false);
         },

--- a/src/app/pages/user/pending/pending.component.ts
+++ b/src/app/pages/user/pending/pending.component.ts
@@ -58,16 +58,17 @@ export class PendingComponent {
     if (!this.pendingItems) {
       return [];
     }
-    return [
-      ...this.pendingItems.platforms.map((platform) => {
+    const platforms =
+      this.pendingItems.platforms?.map((platform) => {
         return {
           id: platform.platform_id,
           name: PLATFORM_NAMES[platform.platform_id] || platform.platform_id,
         };
-      }),
-      ...this.pendingItems.groups.map((group) => {
+      }) || [];
+    const groups =
+      this.pendingItems.groups?.map((group) => {
         return { id: group.group_id, name: group.group_name };
-      }),
-    ];
+      }) || [];
+    return [...platforms, ...groups];
   }
 }

--- a/src/app/pages/user/services/services.component.html
+++ b/src/app/pages/user/services/services.component.html
@@ -5,13 +5,13 @@
       <app-loading-spinner />
     </div>
   } @else {
-    @if (approvedServices.length) {
+    @if (approvedPlatforms.length) {
       <div class="flex flex-col gap-6 p-6 font-light lg:px-48">
-        @for (service of approvedServices; track service.id) {
+        @for (platform of approvedPlatforms; track platform.platform_id) {
           <div
             class="flex items-center justify-between gap-6 rounded-md bg-white p-4"
           >
-            <div class="text-sky-900">{{ service.name }}</div>
+            <div class="text-sky-900">{{ PLATFORM_NAMES[platform.platform_id] }}</div>
             <div class="rounded-full bg-lime-600 px-4 py-2 text-sm text-white">
               Active
             </div>

--- a/src/app/pages/user/services/services.component.spec.ts
+++ b/src/app/pages/user/services/services.component.spec.ts
@@ -1,12 +1,16 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ServicesComponent } from './services.component';
-import { ApiService } from '../../../core/services/api.service';
+import {
+  ApiService,
+  PlatformUserResponse,
+} from '../../../core/services/api.service';
 import { AuthService } from '../../../core/services/auth.service';
 import { provideMockAuth0Service } from '../../../../utils/testingUtils';
 import { provideHttpClient } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
 import { of, throwError } from 'rxjs';
 import { signal } from '@angular/core';
+import { PLATFORM_NAMES } from '../../../core/constants/constants';
 
 describe('ServicesComponent', () => {
   let component: ServicesComponent;
@@ -14,9 +18,11 @@ describe('ServicesComponent', () => {
   let mockApiService: jasmine.SpyObj<ApiService>;
 
   beforeEach(async () => {
-    const apiSpy = jasmine.createSpyObj('ApiService', ['getApprovedServices']);
+    const apiSpy = jasmine.createSpyObj('ApiService', [
+      'getUserApprovedPlatforms',
+    ]);
     const authSpy = jasmine.createSpyObj('AuthService', [], {
-      isAuthenticated: signal(true)
+      isAuthenticated: signal(true),
     });
 
     await TestBed.configureTestingModule({
@@ -26,8 +32,8 @@ describe('ServicesComponent', () => {
         { provide: AuthService, useValue: authSpy },
         provideMockAuth0Service({ isAuthenticated: true }),
         provideHttpClient(),
-        provideRouter([])
-      ]
+        provideRouter([]),
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ServicesComponent);
@@ -36,50 +42,52 @@ describe('ServicesComponent', () => {
   });
 
   it('should create', () => {
-    mockApiService.getApprovedServices.and.returnValue(of({ approved_services: [] }));
+    mockApiService.getUserApprovedPlatforms.and.returnValue(of([]));
     fixture.detectChanges();
     expect(component).toBeTruthy();
   });
 
-  it('should load approved services successfully', () => {
-    const mockServices = [
-      { id: '1', name: 'Test Service', status: 'active', last_updated: '', updated_by: '', resources: [] }
+  it('should load approved platforms successfully', () => {
+    const mockPlatforms: PlatformUserResponse[] = [
+      { platform_id: 'bpa_data_portal', approval_status: 'approved' },
     ];
-    mockApiService.getApprovedServices.and.returnValue(of({ approved_services: mockServices }));
-    
+    mockApiService.getUserApprovedPlatforms.and.returnValue(of(mockPlatforms));
+
     fixture.detectChanges();
-    
-    expect(component.approvedServices).toEqual(mockServices);
+
+    expect(component.approvedPlatforms).toEqual(mockPlatforms);
     expect(component.loading()).toBe(false);
     expect(component.error()).toBeNull();
   });
 
-  it('should handle error when loading services fails', () => {
-    mockApiService.getApprovedServices.and.returnValue(throwError(() => new Error('API Error')));
-    
+  it('should handle error when loading platforms fails', () => {
+    mockApiService.getUserApprovedPlatforms.and.returnValue(
+      throwError(() => new Error('API Error')),
+    );
+
     fixture.detectChanges();
-    
+
     expect(component.loading()).toBe(false);
-    expect(component.error()).toBe('Failed to load approved services');
+    expect(component.error()).toBe('Failed to load approved platforms.');
   });
 
-  it('should display no services message when empty', () => {
-    mockApiService.getApprovedServices.and.returnValue(of({ approved_services: [] }));
+  it('should display no platforms message when empty', () => {
+    mockApiService.getUserApprovedPlatforms.and.returnValue(of([]));
     fixture.detectChanges();
-    
+
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.textContent).toContain('You have no joined services');
   });
 
-  it('should display services when available', () => {
-    const mockServices = [
-      { id: '1', name: 'Test Service', status: 'active', last_updated: '', updated_by: '', resources: [] }
+  it('should display platforms when available', () => {
+    const mockPlatforms: PlatformUserResponse[] = [
+      { platform_id: 'bpa_data_portal', approval_status: 'approved' },
     ];
-    mockApiService.getApprovedServices.and.returnValue(of({ approved_services: mockServices }));
-    
+    mockApiService.getUserApprovedPlatforms.and.returnValue(of(mockPlatforms));
+
     fixture.detectChanges();
-    
+
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.textContent).toContain('Test Service');
+    expect(compiled.textContent).toContain(PLATFORM_NAMES.bpa_data_portal);
   });
 });

--- a/src/app/pages/user/services/services.component.ts
+++ b/src/app/pages/user/services/services.component.ts
@@ -1,11 +1,15 @@
 import { Component, inject, signal } from '@angular/core';
 import { RouterLink, RouterModule } from '@angular/router';
-import { ApiService, Service } from '../../../core/services/api.service';
+import {
+  ApiService,
+  PlatformUserResponse,
+} from '../../../core/services/api.service';
 import { AuthService } from '../../../core/services/auth.service';
 import { LoadingSpinnerComponent } from '../../../shared/components/loading-spinner/loading-spinner.component';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { filter, switchMap } from 'rxjs/operators';
+import { PLATFORM_NAMES } from '../../../core/constants/constants';
 
 @Component({
   selector: 'app-services',
@@ -15,7 +19,7 @@ import { filter, switchMap } from 'rxjs/operators';
   styleUrls: ['./services.component.css'],
 })
 export class ServicesComponent {
-  approvedServices: Service[] = [];
+  approvedPlatforms: PlatformUserResponse[] = [];
   loading = signal(true);
   error = signal<string | null>(null);
 
@@ -27,19 +31,21 @@ export class ServicesComponent {
       .pipe(
         takeUntilDestroyed(),
         filter((isAuthenticated) => isAuthenticated),
-        switchMap(() => this.api.getApprovedServices()),
+        switchMap(() => this.api.getUserApprovedPlatforms()),
       )
       .subscribe({
         next: (res) => {
-          this.approvedServices = res.approved_services || [];
+          this.approvedPlatforms = res || [];
           this.error.set(null);
           this.loading.set(false);
         },
         error: (error) => {
-          console.error('Failed to retrieve approved services', error);
-          this.error.set('Failed to load approved services');
+          console.error('Failed to retrieve approved platforms', error);
+          this.error.set('Failed to load approved platforms.');
           this.loading.set(false);
         },
       });
   }
+
+  protected readonly PLATFORM_NAMES = PLATFORM_NAMES;
 }


### PR DESCRIPTION
## Description

[AAI-251](https://biocloud.atlassian.net/browse/AAI-251): https://github.com/AustralianBioCommons/aai-backend/pull/71 updates the backend to remove groups/services from app_metadata and instead query them from the database. This PR updates the frontend to match

## Changes

- Update platform/group APIs to match backend
- Slight renaming of API functions to distinguish between user and admin endpoints
- Update tests to work with updated APIs

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

## How to Test Manually

Run `npm run test`


[AAI-251]: https://biocloud.atlassian.net/browse/AAI-251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ