### PR TITLE
AAI-421: add admin approve and revoke endpoints for groups and platforms

### DIFF
--- a/src/app/core/services/api.service.spec.ts
+++ b/src/app/core/services/api.service.spec.ts
@@ -127,7 +127,7 @@ describe('ApiService', () => {
     req.flush({ updated: true });
   });
 
-  it('should call revoke platform endpoint with optional reason', () => {
+  it('should call revoke platform endpoint with reason', () => {
     const userId = 'auth0|123';
     const platformId = 'galaxy';
     const reason = 'No longer required';
@@ -143,24 +143,6 @@ describe('ApiService', () => {
     );
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual({ reason });
-    req.flush({ updated: true });
-  });
-
-  it('should call revoke platform endpoint without reason', () => {
-    const userId = 'auth0|123';
-    const platformId = 'galaxy';
-
-    service
-      .revokePlatformAccess(userId, platformId)
-      .subscribe((response) => {
-        expect(response).toEqual({ updated: true });
-      });
-
-    const req = httpMock.expectOne(
-      `${environment.auth0.backend}/admin/users/${userId}/platforms/${platformId}/revoke`,
-    );
-    expect(req.request.method).toBe('POST');
-    expect(req.request.body).toEqual({});
     req.flush({ updated: true });
   });
 
@@ -180,7 +162,7 @@ describe('ApiService', () => {
     req.flush({ updated: true });
   });
 
-  it('should call revoke group endpoint with optional reason', () => {
+  it('should call revoke group endpoint with reason', () => {
     const userId = 'auth0|123';
     const groupId = 'tsi';
     const reason = 'Membership expired';

--- a/src/app/core/services/api.service.spec.ts
+++ b/src/app/core/services/api.service.spec.ts
@@ -110,4 +110,92 @@ describe('ApiService', () => {
     );
     req.flush(mockResponse);
   });
+
+  it('should call approve platform endpoint', () => {
+    const userId = 'auth0|123';
+    const platformId = 'galaxy';
+
+    service.approvePlatformAccess(userId, platformId).subscribe((response) => {
+      expect(response).toEqual({ status: 'ok', updated: true });
+    });
+
+    const req = httpMock.expectOne(
+      `${environment.auth0.backend}/admin/users/${userId}/platforms/${platformId}/approve`,
+    );
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({});
+    req.flush({ status: 'ok', updated: true });
+  });
+
+  it('should call revoke platform endpoint with optional reason', () => {
+    const userId = 'auth0|123';
+    const platformId = 'galaxy';
+    const reason = 'No longer required';
+
+    service
+      .revokePlatformAccess(userId, platformId, reason)
+      .subscribe((response) => {
+        expect(response).toEqual({ status: 'ok', updated: true });
+      });
+
+    const req = httpMock.expectOne(
+      `${environment.auth0.backend}/admin/users/${userId}/platforms/${platformId}/revoke`,
+    );
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ reason });
+    req.flush({ status: 'ok', updated: true });
+  });
+
+  it('should call revoke platform endpoint without reason', () => {
+    const userId = 'auth0|123';
+    const platformId = 'galaxy';
+
+    service
+      .revokePlatformAccess(userId, platformId)
+      .subscribe((response) => {
+        expect(response).toEqual({ status: 'ok', updated: true });
+      });
+
+    const req = httpMock.expectOne(
+      `${environment.auth0.backend}/admin/users/${userId}/platforms/${platformId}/revoke`,
+    );
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({});
+    req.flush({ status: 'ok', updated: true });
+  });
+
+  it('should call approve group endpoint', () => {
+    const userId = 'auth0|123';
+    const groupId = 'tsi';
+
+    service.approveGroupAccess(userId, groupId).subscribe((response) => {
+      expect(response).toEqual({ status: 'ok', updated: true });
+    });
+
+    const req = httpMock.expectOne(
+      `${environment.auth0.backend}/admin/users/${userId}/groups/${groupId}/approve`,
+    );
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({});
+    req.flush({ status: 'ok', updated: true });
+  });
+
+  it('should call revoke group endpoint with optional reason', () => {
+    const userId = 'auth0|123';
+    const groupId = 'tsi';
+    const reason = 'Membership expired';
+
+    service
+      .revokeGroupAccess(userId, groupId, reason)
+      .subscribe((response) => {
+        expect(response).toEqual({ status: 'ok', updated: true });
+      });
+
+    const req = httpMock.expectOne(
+      `${environment.auth0.backend}/admin/users/${userId}/groups/${groupId}/revoke`,
+    );
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ reason });
+    req.flush({ status: 'ok', updated: true });
+  });
 });

--- a/src/app/core/services/api.service.spec.ts
+++ b/src/app/core/services/api.service.spec.ts
@@ -116,7 +116,7 @@ describe('ApiService', () => {
     const platformId = 'galaxy';
 
     service.approvePlatformAccess(userId, platformId).subscribe((response) => {
-      expect(response).toEqual({ status: 'ok', updated: true });
+      expect(response).toEqual({ updated: true });
     });
 
     const req = httpMock.expectOne(
@@ -124,7 +124,7 @@ describe('ApiService', () => {
     );
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual({});
-    req.flush({ status: 'ok', updated: true });
+    req.flush({ updated: true });
   });
 
   it('should call revoke platform endpoint with optional reason', () => {
@@ -135,7 +135,7 @@ describe('ApiService', () => {
     service
       .revokePlatformAccess(userId, platformId, reason)
       .subscribe((response) => {
-        expect(response).toEqual({ status: 'ok', updated: true });
+        expect(response).toEqual({ updated: true });
       });
 
     const req = httpMock.expectOne(
@@ -143,7 +143,7 @@ describe('ApiService', () => {
     );
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual({ reason });
-    req.flush({ status: 'ok', updated: true });
+    req.flush({ updated: true });
   });
 
   it('should call revoke platform endpoint without reason', () => {
@@ -153,7 +153,7 @@ describe('ApiService', () => {
     service
       .revokePlatformAccess(userId, platformId)
       .subscribe((response) => {
-        expect(response).toEqual({ status: 'ok', updated: true });
+        expect(response).toEqual({ updated: true });
       });
 
     const req = httpMock.expectOne(
@@ -161,7 +161,7 @@ describe('ApiService', () => {
     );
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual({});
-    req.flush({ status: 'ok', updated: true });
+    req.flush({ updated: true });
   });
 
   it('should call approve group endpoint', () => {
@@ -169,7 +169,7 @@ describe('ApiService', () => {
     const groupId = 'tsi';
 
     service.approveGroupAccess(userId, groupId).subscribe((response) => {
-      expect(response).toEqual({ status: 'ok', updated: true });
+      expect(response).toEqual({ updated: true });
     });
 
     const req = httpMock.expectOne(
@@ -177,7 +177,7 @@ describe('ApiService', () => {
     );
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual({});
-    req.flush({ status: 'ok', updated: true });
+    req.flush({ updated: true });
   });
 
   it('should call revoke group endpoint with optional reason', () => {
@@ -188,7 +188,7 @@ describe('ApiService', () => {
     service
       .revokeGroupAccess(userId, groupId, reason)
       .subscribe((response) => {
-        expect(response).toEqual({ status: 'ok', updated: true });
+        expect(response).toEqual({ updated: true });
       });
 
     const req = httpMock.expectOne(
@@ -196,6 +196,6 @@ describe('ApiService', () => {
     );
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual({ reason });
-    req.flush({ status: 'ok', updated: true });
+    req.flush({ updated: true });
   });
 });

--- a/src/app/core/services/api.service.ts
+++ b/src/app/core/services/api.service.ts
@@ -156,7 +156,7 @@ export class ApiService {
   ): Observable<{ updated: boolean }> {
     return this.http.post<{ updated: boolean }>(
       `${environment.auth0.backend}/admin/users/${userId}/platforms/${platformId}/revoke`,
-      reason ? { reason } : {},
+      { reason },
     );
   }
 
@@ -177,7 +177,7 @@ export class ApiService {
   ): Observable<{ updated: boolean }> {
     return this.http.post<{ updated: boolean }>(
       `${environment.auth0.backend}/admin/users/${userId}/groups/${groupId}/revoke`,
-      reason ? { reason } : {},
+      { reason },
     );
   }
 

--- a/src/app/core/services/api.service.ts
+++ b/src/app/core/services/api.service.ts
@@ -142,8 +142,8 @@ export class ApiService {
   approvePlatformAccess(
     userId: string,
     platformId: PlatformId,
-  ): Observable<{ status: string; updated: boolean }> {
-    return this.http.post<{ status: string; updated: boolean }>(
+  ): Observable<{ updated: boolean }> {
+    return this.http.post<{ updated: boolean }>(
       `${environment.auth0.backend}/admin/users/${userId}/platforms/${platformId}/approve`,
       {},
     );
@@ -153,8 +153,8 @@ export class ApiService {
     userId: string,
     platformId: PlatformId,
     reason?: string,
-  ): Observable<{ status: string; updated: boolean }> {
-    return this.http.post<{ status: string; updated: boolean }>(
+  ): Observable<{ updated: boolean }> {
+    return this.http.post<{ updated: boolean }>(
       `${environment.auth0.backend}/admin/users/${userId}/platforms/${platformId}/revoke`,
       reason ? { reason } : {},
     );
@@ -163,8 +163,8 @@ export class ApiService {
   approveGroupAccess(
     userId: string,
     groupId: string,
-  ): Observable<{ status: string; updated: boolean }> {
-    return this.http.post<{ status: string; updated: boolean }>(
+  ): Observable<{ updated: boolean }> {
+    return this.http.post<{ updated: boolean }>(
       `${environment.auth0.backend}/admin/users/${userId}/groups/${groupId}/approve`,
       {},
     );
@@ -174,8 +174,8 @@ export class ApiService {
     userId: string,
     groupId: string,
     reason?: string,
-  ): Observable<{ status: string; updated: boolean }> {
-    return this.http.post<{ status: string; updated: boolean }>(
+  ): Observable<{ updated: boolean }> {
+    return this.http.post<{ updated: boolean }>(
       `${environment.auth0.backend}/admin/users/${userId}/groups/${groupId}/revoke`,
       reason ? { reason } : {},
     );

--- a/src/app/core/services/api.service.ts
+++ b/src/app/core/services/api.service.ts
@@ -139,6 +139,48 @@ export class ApiService {
     );
   }
 
+  approvePlatformAccess(
+    userId: string,
+    platformId: PlatformId,
+  ): Observable<{ status: string; updated: boolean }> {
+    return this.http.post<{ status: string; updated: boolean }>(
+      `${environment.auth0.backend}/admin/users/${userId}/platforms/${platformId}/approve`,
+      {},
+    );
+  }
+
+  revokePlatformAccess(
+    userId: string,
+    platformId: PlatformId,
+    reason?: string,
+  ): Observable<{ status: string; updated: boolean }> {
+    return this.http.post<{ status: string; updated: boolean }>(
+      `${environment.auth0.backend}/admin/users/${userId}/platforms/${platformId}/revoke`,
+      reason ? { reason } : {},
+    );
+  }
+
+  approveGroupAccess(
+    userId: string,
+    groupId: string,
+  ): Observable<{ status: string; updated: boolean }> {
+    return this.http.post<{ status: string; updated: boolean }>(
+      `${environment.auth0.backend}/admin/users/${userId}/groups/${groupId}/approve`,
+      {},
+    );
+  }
+
+  revokeGroupAccess(
+    userId: string,
+    groupId: string,
+    reason?: string,
+  ): Observable<{ status: string; updated: boolean }> {
+    return this.http.post<{ status: string; updated: boolean }>(
+      `${environment.auth0.backend}/admin/users/${userId}/groups/${groupId}/revoke`,
+      reason ? { reason } : {},
+    );
+  }
+
   resendVerificationEmail(userId: string): Observable<{ message: string }> {
     return this.http.post<{ message: string }>(
       `${environment.auth0.backend}/admin/users/${userId}/verification-email/resend`,

--- a/src/app/core/services/api.service.ts
+++ b/src/app/core/services/api.service.ts
@@ -152,7 +152,7 @@ export class ApiService {
   revokePlatformAccess(
     userId: string,
     platformId: PlatformId,
-    reason?: string,
+    reason: string,
   ): Observable<{ updated: boolean }> {
     return this.http.post<{ updated: boolean }>(
       `${environment.auth0.backend}/admin/users/${userId}/platforms/${platformId}/revoke`,
@@ -173,7 +173,7 @@ export class ApiService {
   revokeGroupAccess(
     userId: string,
     groupId: string,
-    reason?: string,
+    reason: string,
   ): Observable<{ updated: boolean }> {
     return this.http.post<{ updated: boolean }>(
       `${environment.auth0.backend}/admin/users/${userId}/groups/${groupId}/revoke`,


### PR DESCRIPTION
## Description

[AAI-421](https://biocloud.atlassian.net/browse/AAI-421): Add admin approve and revoke services API for platforms and groups accordingly.

## Changes

- Added services APIs for admin approve/revoke for platforms and groups

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

## How to Test Manually

```
npm test -- --watch=false --browsers=ChromeHeadless --include src/app/core/services/api.service.spec.ts
```
## Screenshots for any UI changes

No UI changes.

## Related pull requests
Dependent on https://github.com/AustralianBioCommons/aai-backend/pull/81

[AAI-421]: https://biocloud.atlassian.net/browse/AAI-421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ