### PR TITLE
docs: add reminder to update secrets in spreadsheet and github action secrets

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,7 @@
 - [ ] I have added unit / integration tests that prove my fix is effective or that my feature works
 - [ ] I have run all tests locally and they pass
 - [ ] I have updated the documentation (if applicable)
+- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-portal/settings/secrets/actions).
 
 ## How to Test Manually
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ This project was generated using [Angular CLI](https://github.com/angular/angula
 - `main` branch is manually synced from `test` branch.
   - Automated releases from `main` branch will be added in [AAI-154](https://biocloud.atlassian.net/browse/AAI-154).
 
-
 ## Development server
 
 To start a local development server, run:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ This project was generated using [Angular CLI](https://github.com/angular/angula
   - Automated deployment will be added in [AAI-153](https://biocloud.atlassian.net/browse/AAI-153).
 - `main` branch is manually synced from `test` branch.
   - Automated releases from `main` branch will be added in [AAI-154](https://biocloud.atlassian.net/browse/AAI-154).
+ 
+### Secrets Configuration
+This repository references a [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) (ask the AAI dev team for access if required) used to manage environment variables and other sensitive values, usually set in [Github Secrets](https://github.com/AustralianBioCommons/aai-portal/settings/secrets/actions). 
+
+For any new or updated secrets, the entries in the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) should be updated and synced with the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-portal/settings/secrets/actions).
 
 ## Development server
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,7 @@ This project was generated using [Angular CLI](https://github.com/angular/angula
   - Automated deployment will be added in [AAI-153](https://biocloud.atlassian.net/browse/AAI-153).
 - `main` branch is manually synced from `test` branch.
   - Automated releases from `main` branch will be added in [AAI-154](https://biocloud.atlassian.net/browse/AAI-154).
- 
-### Secrets Configuration
-This repository references a [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) (ask the AAI dev team for access if required) used to manage environment variables and other sensitive values, usually set in [Github Secrets](https://github.com/AustralianBioCommons/aai-portal/settings/secrets/actions). 
 
-For any new or updated secrets, the entries in the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) should be updated and synced with the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-portal/settings/secrets/actions).
 
 ## Development server
 


### PR DESCRIPTION
This pull request documents and remind us to manage secrets.

## Changes

- Updated pull request template to remind us to update secrets


## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit / integration tests that prove my fix is effective or that my feature works
- [ ] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

