### PR TITLE
Remove login guard terms and conditions

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -39,7 +39,6 @@ export const routes: Routes = [
   {
     path: 'terms/biocommons',
     component: BiocommonsTermsComponent,
-    canActivate: [loginGuard],
     data: { title: 'BioCommons Access Terms & Conditions' },
   },
   {

--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -249,4 +249,58 @@ describe('AuthService', () => {
 
     httpMock.expectNone(`${environment.auth0.backend}/me/is-general-admin`);
   });
+
+  it('should capture auth error from query parameters', () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/?error=access_denied&error_description=User%20is%20blocked',
+    );
+
+    const { httpMock } = createService(false);
+
+    expect(service.authError()).toEqual({
+      error: 'access_denied',
+      error_description: 'User is blocked',
+      state: undefined,
+    });
+
+    httpMock.expectNone(`${environment.auth0.backend}/me/is-general-admin`);
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('should capture auth error from hash parameters', () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/#error=access_denied&error_description=Blocked',
+    );
+
+    const { httpMock } = createService(false);
+
+    expect(service.authError()).toEqual({
+      error: 'access_denied',
+      error_description: 'Blocked',
+      state: undefined,
+    });
+
+    httpMock.expectNone(`${environment.auth0.backend}/me/is-general-admin`);
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('should fall back to a default message when error description is missing', () => {
+    window.history.replaceState({}, '', '/?error=access_denied');
+
+    const { httpMock } = createService(false);
+
+    expect(service.authError()).toEqual({
+      error: 'access_denied',
+      error_description:
+        'An error occurred during authentication. Please try again.',
+      state: undefined,
+    });
+
+    httpMock.expectNone(`${environment.auth0.backend}/me/is-general-admin`);
+    window.history.replaceState({}, '', '/');
+  });
 });

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -167,14 +167,23 @@ export class AuthService {
    */
   private checkForAuthErrors(): void {
     const urlParams = new URLSearchParams(window.location.search);
-    const error = urlParams.get('error');
-    const errorDescription = urlParams.get('error_description');
-    const state = urlParams.get('state');
+    const hash = window.location.hash.startsWith('#')
+      ? window.location.hash.slice(1)
+      : window.location.hash;
+    const hashParams = new URLSearchParams(hash);
 
-    if (error && errorDescription) {
+    const error = urlParams.get('error') ?? hashParams.get('error');
+    const errorDescription =
+      urlParams.get('error_description') ??
+      hashParams.get('error_description');
+    const state = urlParams.get('state') ?? hashParams.get('state');
+
+    if (error) {
       this.authError.set({
         error,
-        error_description: errorDescription,
+        error_description:
+          errorDescription ||
+          'An error occurred during authentication. Please try again.',
         state: state || undefined,
       });
     }

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -174,8 +174,7 @@ export class AuthService {
 
     const error = urlParams.get('error') ?? hashParams.get('error');
     const errorDescription =
-      urlParams.get('error_description') ??
-      hashParams.get('error_description');
+      urlParams.get('error_description') ?? hashParams.get('error_description');
     const state = urlParams.get('state') ?? hashParams.get('state');
 
     if (error) {


### PR DESCRIPTION
## Description

Remove login guard for terms and conditions.

## Changes

- Removed the login guard from the BioCommons terms route so it’s accessible during registration.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-portal/settings/secrets/actions).


## Screenshots for any UI changes

https://github.com/user-attachments/assets/b80f6273-2d1e-49d4-8247-8decdef43d06

