### PR TITLE
feat: confirm password during password change

### DIFF
--- a/src/app/pages/user/profile/profile.component.html
+++ b/src/app/pages/user/profile/profile.component.html
@@ -238,6 +238,34 @@
                 </div>
               }
             </div>
+
+            <div>
+              <label
+                class="block text-sm font-medium text-gray-900"
+                for="modal-confirm-password"
+              >
+                Confirm new password
+              </label>
+              <input
+                id="modal-confirm-password"
+                type="password"
+                formControlName="confirmPassword"
+                class="mt-1 block w-full rounded-md border p-3 text-sm focus:outline-none focus:ring-2 focus:ring-sky-100"
+                [class.border-red-500]="
+                  isFieldInvalid(passwordForm, 'confirmPassword')
+                "
+              />
+              @if (isFieldInvalid(passwordForm, "confirmPassword")) {
+                <div class="mt-0.5 text-xs text-red-500">
+                  @for (
+                    error of getErrorMessages(passwordForm, "confirmPassword");
+                    track error
+                  ) {
+                    {{ error }}<br />
+                  }
+                </div>
+              }
+            </div>
           </form>
         }
       }

--- a/src/app/pages/user/profile/profile.component.spec.ts
+++ b/src/app/pages/user/profile/profile.component.spec.ts
@@ -450,6 +450,7 @@ describe('ProfileComponent', () => {
   it('handles a successful password change', () => {
     component.passwordForm.controls.currentPassword.setValue('Current123!');
     component.passwordForm.controls.newPassword.setValue('NewPassword1!');
+    component.passwordForm.controls.confirmPassword.setValue('NewPassword1!');
 
     fixture.detectChanges();
     updatePassword();
@@ -481,6 +482,7 @@ describe('ProfileComponent', () => {
     openModal('password');
     component.passwordForm.controls.currentPassword.setValue('Current123!');
     component.passwordForm.controls.newPassword.setValue('ValidPassword1!');
+    component.passwordForm.controls.confirmPassword.setValue('ValidPassword1!');
 
     fixture.detectChanges();
     updatePassword();
@@ -515,6 +517,7 @@ describe('ProfileComponent', () => {
     openModal('password');
     component.passwordForm.controls.currentPassword.setValue('WrongPassword1!');
     component.passwordForm.controls.newPassword.setValue('NewValid1!');
+    component.passwordForm.controls.confirmPassword.setValue('NewValid1!');
 
     fixture.detectChanges();
     updatePassword();
@@ -702,6 +705,7 @@ describe('ProfileComponent', () => {
       component.passwordForm.patchValue({
         currentPassword: 'SamePass123!',
         newPassword: 'SamePass123!',
+        confirmPassword: 'SamePass123!',
       });
       component.passwordForm.markAllAsTouched();
 
@@ -728,6 +732,7 @@ describe('ProfileComponent', () => {
       component.passwordForm.patchValue({
         currentPassword: 'OldPass123!',
         newPassword: 'NewPass123!',
+        confirmPassword: 'NewPass123!',
       });
 
       expect(

--- a/src/app/pages/user/profile/profile.component.ts
+++ b/src/app/pages/user/profile/profile.component.ts
@@ -131,6 +131,7 @@ export class ProfileComponent implements OnInit {
   passwordForm = this.formBuilder.nonNullable.group({
     currentPassword: ['', Validators.required],
     newPassword: ['', passwordRequirements],
+    confirmPassword: ['', [Validators.required, Validators.maxLength(72)]],
   });
 
   activeModal = signal<ProfileModal | null>(null);
@@ -151,6 +152,11 @@ export class ProfileComponent implements OnInit {
   ngOnInit(): void {
     this.loadUserProfile();
     this.validationService.setupPasswordDifferentValidation(this.passwordForm);
+    this.validationService.setupPasswordConfirmationValidation(
+      this.passwordForm,
+      'newPassword',
+      'confirmPassword',
+    );
     this.usernameForm.get('username')?.valueChanges.subscribe(() => {
       if (this.validationService.hasFieldBackendError('username')) {
         this.validationService.clearFieldBackendError('username');
@@ -200,7 +206,11 @@ export class ProfileComponent implements OnInit {
         this.validationService.clearFieldBackendError('email');
         break;
       case 'password':
-        this.passwordForm.reset({ currentPassword: '', newPassword: '' });
+        this.passwordForm.reset({
+          currentPassword: '',
+          newPassword: '',
+          confirmPassword: '',
+        });
         break;
     }
     this.activeModal.set(type);


### PR DESCRIPTION
## Description

Have users' confirm password when changed

## Changes
- Added `confirmPassword` to the password form with required + max length validation.
- Hooked up password confirmation validation against `newPassword`.
- Added the new input + error display in the modal.
- Updated specs to set confirmPassword so tests remain valid.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-portal/settings/secrets/actions).

## How to Test Manually

<img width="1512" height="819" alt="Screenshot 2026-03-20 at 11 17 02 am" src="https://github.com/user-attachments/assets/2284fa16-9188-414e-ae9b-c848541e6304" />

