### PR TITLE
fix: add username and email in filter to hide admins

### DIFF
--- a/src/app/pages/admin/components/user-list/user-list.component.spec.ts
+++ b/src/app/pages/admin/components/user-list/user-list.component.spec.ts
@@ -135,7 +135,7 @@ describe('UserListComponent', () => {
 
   it('should filter out the current user from the list', fakeAsync(() => {
     userSignal.set({
-      user_id: '1',
+      user_id: 'does-not-match',
       email: 'user1@example.com',
       email_verified: true,
       username: 'user1',
@@ -151,6 +151,7 @@ describe('UserListComponent', () => {
     tick(250);
 
     expect(component.users()).toEqual([mockUsers[1]]);
+    expect(component.totalUsers()).toBe(99);
   }));
 
   it('should display the title', () => {

--- a/src/app/pages/admin/components/user-list/user-list.component.ts
+++ b/src/app/pages/admin/components/user-list/user-list.component.ts
@@ -121,6 +121,12 @@ export class UserListComponent implements OnInit {
   adminPlatforms = this.authService.adminPlatforms;
   adminGroups = this.authService.adminGroups;
   currentUserId = computed(() => this.authService.user()?.user_id ?? null);
+  currentUserEmail = computed(
+    () => this.authService.user()?.email?.toLowerCase() ?? null,
+  );
+  currentUsername = computed(
+    () => this.authService.user()?.username?.toLowerCase() ?? null,
+  );
 
   readonly isSbpAdmin = computed(
     () =>
@@ -341,9 +347,13 @@ export class UserListComponent implements OnInit {
       .subscribe({
         next: (users: BiocommonsUserResponse[]) => {
           const filteredUsers = this.filterOutCurrentUser(users);
+          const removedCount = users.length - filteredUsers.length;
           this.users.set(
             append ? [...this.users(), ...filteredUsers] : filteredUsers,
           );
+          if (removedCount > 0) {
+            this.totalUsers.set(Math.max(0, this.totalUsers() - removedCount));
+          }
           this.finishLoading(start);
         },
         error: (error: unknown) => {
@@ -410,9 +420,22 @@ export class UserListComponent implements OnInit {
     users: BiocommonsUserResponse[],
   ): BiocommonsUserResponse[] {
     const currentUserId = this.currentUserId();
-    if (!currentUserId) {
+    const currentUserEmail = this.currentUserEmail();
+    const currentUsername = this.currentUsername();
+    if (!currentUserId && !currentUserEmail && !currentUsername) {
       return users;
     }
-    return users.filter((user) => user.id !== currentUserId);
+    return users.filter((user) => {
+      if (currentUserId && user.id === currentUserId) {
+        return false;
+      }
+      if (currentUserEmail && user.email?.toLowerCase() === currentUserEmail) {
+        return false;
+      }
+      if (currentUsername && user.username?.toLowerCase() === currentUsername) {
+        return false;
+      }
+      return true;
+    });
   }
 }


### PR DESCRIPTION
## Description

The previous filter on the admin dashboard was only matching on `user_id` vs the list’s id. If those don’t match (common with some admin lists), the entry won’t be filtered.

## Changes

- Broadened the filter to also exclude by email and username (case‑insensitive), and also decrement the visible total when we filter one out in `aai-portal/src/app/pages/admin/components/user-list/user-list.component.ts`
- Updated test

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-portal/settings/secrets/actions).
