### PR TITLE
fix: add back sbp url

### DIFF
--- a/src/assets/config/app-config.json
+++ b/src/assets/config/app-config.json
@@ -12,6 +12,6 @@
   "platformUrls": {
     "bpaPlatform": "https://aaidemo.bioplatforms.com",
     "galaxyPlatform": "https://dev.gvl.org.au",
-    "sbpPlatform": ""
+    "sbpPlatform": "https://dev.sbp.test.biocommons.org.au"
   }
 }


### PR DESCRIPTION
## Description

Add back the missing SBP url in the app-config.json

## Changes

- Add back the SBP url in the app-config.json


## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-portal/settings/secrets/actions).
