### PR TITLE
feat: update SBP admin dashboard title

### DIFF
--- a/src/app/core/constants/constants.ts
+++ b/src/app/core/constants/constants.ts
@@ -68,6 +68,15 @@ export const BIOCOMMONS_BUNDLES: Bundle[] = [
 ];
 
 /**
+ * Maps platform IDs to the bundle group ID whose admin access is granted by
+ * the same Auth0 role as the platform admin role (biocommons/role/{platform}/admin).
+ * Mirrors the backend PLATFORM_BUNDLE_GROUP_MAP in scheduled_tasks/tasks.py.
+ */
+export const PLATFORM_BUNDLE_GROUP_MAP: Partial<Record<PlatformId, string>> = {
+  sbp: 'biocommons/group/sbp_workflow_execution',
+};
+
+/**
  * Allowed email domains for SBP (Structural Biology Platform) registration
  */
 export const SBP_ALLOWED_EMAIL_DOMAINS = [

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -13,8 +13,14 @@ import {
 } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { AdminPlatformResponse, AdminGroupResponse } from './api.service';
+import { PLATFORM_BUNDLE_GROUP_MAP } from '../constants/constants';
 
-export type AdminType = 'biocommons' | 'platform' | 'bundle' | null;
+export type AdminType =
+  | 'biocommons'
+  | 'platform'
+  | 'platform-bundle'
+  | 'bundle'
+  | null;
 
 export interface AuthError {
   error: string;
@@ -143,6 +149,18 @@ export class AuthService {
 
     const platforms = this.adminPlatforms();
     const groups = this.adminGroups();
+
+    // Platform-bundle admin: single platform whose groups are exactly its
+    // associated bundles (e.g. SBP admin). Detected before 'biocommons' so it
+    // doesn't inherit the broader biocommons privileges in the UI.
+    if (
+      platforms.length === 1 &&
+      groups.length > 0 &&
+      groups.every((g) =>
+        platforms.some((p) => PLATFORM_BUNDLE_GROUP_MAP[p.id] === g.id),
+      )
+    )
+      return 'platform-bundle';
 
     // BioCommons admin: manages multiple platforms or both platforms and groups
     if (platforms.length > 1 || (platforms.length && groups.length))

--- a/src/app/pages/admin/components/user-list/user-list.component.html
+++ b/src/app/pages/admin/components/user-list/user-list.component.html
@@ -32,7 +32,11 @@
       <!-- Search bar -->
       <div
         class="w-full"
-        [ngClass]="adminType() === 'bundle' ? 'md:w-full' : 'md:w-2/3'"
+        [ngClass]="
+          adminType() === 'bundle' || adminType() === 'platform-bundle'
+            ? 'md:w-full'
+            : 'md:w-2/3'
+        "
       >
         <label
           for="search-input"
@@ -68,7 +72,7 @@
       </div>
 
       <!-- Filter dropdown -->
-      @if (adminType() !== "bundle") {
+      @if (adminType() !== "bundle" && adminType() !== "platform-bundle") {
         <div class="w-full md:w-1/3">
           <label
             for="filter-select"
@@ -98,14 +102,18 @@
     >
       <div
         class="flex-1"
-        [ngClass]="adminType() !== 'bundle' ? 'w-6/12' : 'w-8/12'"
+        [ngClass]="
+          adminType() !== 'bundle' && adminType() !== 'platform-bundle'
+            ? 'w-6/12'
+            : 'w-8/12'
+        "
       >
         Total:
         <span class="font-light text-gray-300">{{ totalUsers() }} users</span>
       </div>
       <div class="w-2/12">
         {{
-          adminType() !== "bundle"
+          adminType() !== "bundle" && adminType() !== "platform-bundle"
             ? "Bundles"
             : adminGroups()[0].short_name + " Bundle Access"
         }}
@@ -340,7 +348,8 @@
                       track platform.id
                     ) {
                       @if (
-                        adminType() === "platform" &&
+                        (adminType() === "platform" ||
+                          adminType() === "platform-bundle") &&
                         platform.platform_id === adminPlatforms()[0].id
                       ) {
                         <div
@@ -424,7 +433,8 @@
                         platform.approval_status === "approved" &&
                         ((adminType() === "biocommons" &&
                           user.platform_memberships.length === 1) ||
-                          (adminType() === "platform" &&
+                          ((adminType() === "platform" ||
+                            adminType() === "platform-bundle") &&
                             platform.platform_id === adminPlatforms()[0].id))
                       ) {
                         <button

--- a/src/app/pages/admin/user-details/user-details.component.html
+++ b/src/app/pages/admin/user-details/user-details.component.html
@@ -116,6 +116,7 @@
         @let showActionButton =
           !user()?.email_verified ||
           adminType() === "platform" ||
+          adminType() === "platform-bundle" ||
           adminType() === "biocommons";
         @if (showActionButton) {
           <app-dropdown-menu
@@ -146,7 +147,11 @@
                   Resend Verification Email
                 </button>
               }
-              @if (adminType() === "platform" || adminType() === "biocommons") {
+              @if (
+                adminType() === "platform" ||
+                adminType() === "platform-bundle" ||
+                adminType() === "biocommons"
+              ) {
                 <button
                   class="flex w-full items-center gap-2 px-4 py-2 text-sm text-gray-700 transition-all hover:bg-gray-100 hover:text-gray-900"
                   role="menuitem"

--- a/src/app/shared/components/navbar/navbar.component.ts
+++ b/src/app/shared/components/navbar/navbar.component.ts
@@ -134,6 +134,9 @@ export class NavbarComponent {
         : 'Dashboard';
 
     if (this.adminType() === 'biocommons') {
+      if (this.adminPlatforms().length === 1) {
+        return `${this.adminPlatforms()[0].name} Admin ${suffix}`;
+      }
       return `BioCommons Admin ${suffix}`;
     } else if (this.adminType() === 'platform') {
       return `${this.adminPlatforms()[0].name} Admin ${suffix}`;

--- a/src/app/shared/components/navbar/navbar.component.ts
+++ b/src/app/shared/components/navbar/navbar.component.ts
@@ -13,7 +13,6 @@ import {
 
 import { toSignal } from '@angular/core/rxjs-interop';
 import { DataRefreshService } from '../../../core/services/data-refresh.service';
-import { PLATFORM_BUNDLE_GROUP_MAP } from '../../../core/constants/constants';
 import { DropdownMenuComponent } from '../dropdown-menu/dropdown-menu.component';
 import { filter } from 'rxjs';
 import { NgIcon, provideIcons } from '@ng-icons/core';
@@ -135,22 +134,11 @@ export class NavbarComponent {
         : 'Dashboard';
 
     if (this.adminType() === 'biocommons') {
-      const platforms = this.adminPlatforms();
-      const groups = this.adminGroups();
-      // Show the platform name only when this is a single-platform admin whose
-      // groups are exactly the bundles associated with that platform — i.e. an
-      // SBP-style admin, not a true multi-resource BioCommons admin.
-      const allGroupsArePlatformBundles =
-        platforms.length === 1 &&
-        groups.length > 0 &&
-        groups.every((g) =>
-          platforms.some((p) => PLATFORM_BUNDLE_GROUP_MAP[p.id] === g.id),
-        );
-      if (allGroupsArePlatformBundles) {
-        return `${platforms[0].name} Admin ${suffix}`;
-      }
       return `BioCommons Admin ${suffix}`;
-    } else if (this.adminType() === 'platform') {
+    } else if (
+      this.adminType() === 'platform' ||
+      this.adminType() === 'platform-bundle'
+    ) {
       return `${this.adminPlatforms()[0].name} Admin ${suffix}`;
     }
 

--- a/src/app/shared/components/navbar/navbar.component.ts
+++ b/src/app/shared/components/navbar/navbar.component.ts
@@ -13,6 +13,7 @@ import {
 
 import { toSignal } from '@angular/core/rxjs-interop';
 import { DataRefreshService } from '../../../core/services/data-refresh.service';
+import { PLATFORM_BUNDLE_GROUP_MAP } from '../../../core/constants/constants';
 import { DropdownMenuComponent } from '../dropdown-menu/dropdown-menu.component';
 import { filter } from 'rxjs';
 import { NgIcon, provideIcons } from '@ng-icons/core';
@@ -134,8 +135,19 @@ export class NavbarComponent {
         : 'Dashboard';
 
     if (this.adminType() === 'biocommons') {
-      if (this.adminPlatforms().length === 1) {
-        return `${this.adminPlatforms()[0].name} Admin ${suffix}`;
+      const platforms = this.adminPlatforms();
+      const groups = this.adminGroups();
+      // Show the platform name only when this is a single-platform admin whose
+      // groups are exactly the bundles associated with that platform — i.e. an
+      // SBP-style admin, not a true multi-resource BioCommons admin.
+      const allGroupsArePlatformBundles =
+        platforms.length === 1 &&
+        groups.length > 0 &&
+        groups.every((g) =>
+          platforms.some((p) => PLATFORM_BUNDLE_GROUP_MAP[p.id] === g.id),
+        );
+      if (allGroupsArePlatformBundles) {
+        return `${platforms[0].name} Admin ${suffix}`;
       }
       return `BioCommons Admin ${suffix}`;
     } else if (this.adminType() === 'platform') {


### PR DESCRIPTION
## Description

[AAI-828](https://biocloud.atlassian.net/browse/AAI-828): Update dashboard title for SBP admins

## Changes

- As an SBP admin manages both a platform and a bundle (unlike TSI which is bundle-only), they get the richer admin dashboard with platform and bundle columns and filter controls — appropriate given they can take actions on both. The dashboard title correctly shows "Structural Biology Platform Admin Dashboard".


Backend changes are in: https://github.com/AustralianBioCommons/aai-backend/pull/269


## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-portal/settings/secrets/actions).



[AAI-828]: https://biocloud.atlassian.net/browse/AAI-828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ