### PR TITLE
fix: add filter back for SBP admin dashboard

### DIFF
--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -7,6 +7,7 @@ import {
 import { of, throwError } from 'rxjs';
 import { AuthService as Auth0Service } from '@auth0/auth0-angular';
 import { AuthService, BiocommonsAuth0User } from './auth.service';
+import { AdminPlatformResponse, AdminGroupResponse } from './api.service';
 import { environment } from '../../../environments/environment';
 
 describe('AuthService', () => {
@@ -248,5 +249,78 @@ describe('AuthService', () => {
     });
 
     httpMock.expectNone(`${environment.auth0.backend}/me/is-general-admin`);
+  });
+
+  describe('adminType', () => {
+    const sbpPlatform: AdminPlatformResponse = {
+      id: 'sbp',
+      name: 'Structural Biology Platform',
+    };
+    const sbpGroup: AdminGroupResponse = {
+      id: 'biocommons/group/sbp_workflow_execution',
+      name: 'SBP Workflow Execution',
+      short_name: 'SBP',
+    };
+    const galaxyPlatform: AdminPlatformResponse = {
+      id: 'galaxy',
+      name: 'Galaxy Australia',
+    };
+    const otherGroup: AdminGroupResponse = {
+      id: 'biocommons/group/other',
+      name: 'Other Group',
+      short_name: 'Other',
+    };
+
+    function flushAdminTypeRequests(
+      isAdmin: boolean,
+      platforms: AdminPlatformResponse[],
+      groups: AdminGroupResponse[],
+    ) {
+      httpMock
+        .expectOne(`${environment.auth0.backend}/me/is-general-admin`)
+        .flush(isAdmin);
+      httpMock
+        .expectOne(`${environment.auth0.backend}/me/platforms/admin-roles`)
+        .flush(platforms);
+      httpMock
+        .expectOne(`${environment.auth0.backend}/me/groups/admin-roles`)
+        .flush(groups);
+    }
+
+    it('returns null when not a general admin', () => {
+      createService();
+      flushAdminTypeRequests(false, [], []);
+      expect(service.adminType()).toBeNull();
+    });
+
+    it('returns "platform-bundle" for SBP admin (single platform with its associated bundle group)', () => {
+      createService();
+      flushAdminTypeRequests(true, [sbpPlatform], [sbpGroup]);
+      expect(service.adminType()).toBe('platform-bundle');
+    });
+
+    it('returns "biocommons" not "platform-bundle" when SBP admin also has an unrelated group', () => {
+      createService();
+      flushAdminTypeRequests(true, [sbpPlatform], [sbpGroup, otherGroup]);
+      expect(service.adminType()).toBe('biocommons');
+    });
+
+    it('returns "biocommons" for admin with multiple platforms', () => {
+      createService();
+      flushAdminTypeRequests(true, [sbpPlatform, galaxyPlatform], []);
+      expect(service.adminType()).toBe('biocommons');
+    });
+
+    it('returns "platform" for single-platform admin with no groups', () => {
+      createService();
+      flushAdminTypeRequests(true, [galaxyPlatform], []);
+      expect(service.adminType()).toBe('platform');
+    });
+
+    it('returns "bundle" for admin with groups but no platforms', () => {
+      createService();
+      flushAdminTypeRequests(true, [], [otherGroup]);
+      expect(service.adminType()).toBe('bundle');
+    });
   });
 });

--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -304,6 +304,5 @@ describe('AuthService', () => {
       flushAdminTypeRequests(true, [sbpPlatform, galaxyPlatform], []);
       expect(service.adminType()).toBe('biocommons');
     });
-
   });
 });

--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -287,12 +287,6 @@ describe('AuthService', () => {
         .flush(groups);
     }
 
-    it('returns null when not a general admin', () => {
-      createService();
-      flushAdminTypeRequests(false, [], []);
-      expect(service.adminType()).toBeNull();
-    });
-
     it('returns "platform-bundle" for SBP admin (single platform with its associated bundle group)', () => {
       createService();
       flushAdminTypeRequests(true, [sbpPlatform], [sbpGroup]);
@@ -311,16 +305,5 @@ describe('AuthService', () => {
       expect(service.adminType()).toBe('biocommons');
     });
 
-    it('returns "platform" for single-platform admin with no groups', () => {
-      createService();
-      flushAdminTypeRequests(true, [galaxyPlatform], []);
-      expect(service.adminType()).toBe('platform');
-    });
-
-    it('returns "bundle" for admin with groups but no platforms', () => {
-      createService();
-      flushAdminTypeRequests(true, [], [otherGroup]);
-      expect(service.adminType()).toBe('bundle');
-    });
   });
 });

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from '@angular/common/http';
-import { Injectable, inject, signal, computed, DOCUMENT } from '@angular/core';
+import { Injectable, inject, signal, computed } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { AuthService as Auth0Service } from '@auth0/auth0-angular';
 import {

--- a/src/app/core/services/branding.service.spec.ts
+++ b/src/app/core/services/branding.service.spec.ts
@@ -1,4 +1,4 @@
-import { DOCUMENT } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import { TestBed } from '@angular/core/testing';
 import { Title } from '@angular/platform-browser';
 import {

--- a/src/app/core/services/branding.service.ts
+++ b/src/app/core/services/branding.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, inject, DOCUMENT } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import { Title } from '@angular/platform-browser';
 import { Router, NavigationEnd, ActivatedRoute } from '@angular/router';
 

--- a/src/app/pages/admin/components/user-list/user-list.component.html
+++ b/src/app/pages/admin/components/user-list/user-list.component.html
@@ -32,11 +32,7 @@
       <!-- Search bar -->
       <div
         class="w-full"
-        [ngClass]="
-          adminType() === 'bundle' || adminType() === 'platform-bundle'
-            ? 'md:w-full'
-            : 'md:w-2/3'
-        "
+        [ngClass]="adminType() === 'bundle' ? 'md:w-full' : 'md:w-2/3'"
       >
         <label
           for="search-input"
@@ -72,7 +68,7 @@
       </div>
 
       <!-- Filter dropdown -->
-      @if (adminType() !== "bundle" && adminType() !== "platform-bundle") {
+      @if (adminType() !== "bundle") {
         <div class="w-full md:w-1/3">
           <label
             for="filter-select"
@@ -102,11 +98,7 @@
     >
       <div
         class="flex-1"
-        [ngClass]="
-          adminType() !== 'bundle' && adminType() !== 'platform-bundle'
-            ? 'w-6/12'
-            : 'w-8/12'
-        "
+        [ngClass]="adminType() !== 'bundle' ? 'w-6/12' : 'w-8/12'"
       >
         Total:
         <span class="font-light text-gray-300">{{ totalUsers() }} users</span>
@@ -126,7 +118,8 @@
             {{
               adminType() === "biocommons"
                 ? "Services"
-                : adminType() === "platform"
+                : adminType() === "platform" ||
+                    adminType() === "platform-bundle"
                   ? adminPlatforms()[0].name + " Access"
                   : "Access"
             }}

--- a/src/app/pages/admin/unverified-users/unverified-users.component.ts
+++ b/src/app/pages/admin/unverified-users/unverified-users.component.ts
@@ -1,4 +1,5 @@
-import { Component, inject, DOCUMENT } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import {
   AdminGetUsersApiParams,
   ApiService,

--- a/src/app/pages/admin/user-details/user-details.component.spec.ts
+++ b/src/app/pages/admin/user-details/user-details.component.spec.ts
@@ -83,12 +83,12 @@ describe('UserDetailsComponent', () => {
     ]);
     const routerSpy = jasmine.createSpyObj(
       'Router',
-      ['currentNavigation', 'createUrlTree', 'serializeUrl', 'navigate'],
+      ['getCurrentNavigation', 'createUrlTree', 'serializeUrl', 'navigate'],
       {
         events: EMPTY,
       },
     );
-    routerSpy.currentNavigation.and.returnValue(null);
+    routerSpy.getCurrentNavigation.and.returnValue(null);
     routerSpy.createUrlTree.and.returnValue({} as UrlTree);
     routerSpy.serializeUrl.and.returnValue('/mocked-url');
 
@@ -405,7 +405,7 @@ describe('UserDetailsComponent', () => {
 
   it('should set returnUrl from navigation state', () => {
     const mockRouter = TestBed.inject(Router) as jasmine.SpyObj<Router>;
-    mockRouter.currentNavigation.and.returnValue({
+    mockRouter.getCurrentNavigation.and.returnValue({
       id: 1,
       initialUrl: {} as UrlTree,
       extractedUrl: {} as UrlTree,
@@ -431,7 +431,7 @@ describe('UserDetailsComponent', () => {
 
   it('should set returnUrl from history state when navigation state is not available', () => {
     const mockRouter = TestBed.inject(Router) as jasmine.SpyObj<Router>;
-    mockRouter.currentNavigation.and.returnValue(null);
+    mockRouter.getCurrentNavigation.and.returnValue(null);
 
     spyOnProperty(history, 'state', 'get').and.returnValue({
       returnUrl: '/revoked-users',

--- a/src/app/pages/admin/user-details/user-details.component.spec.ts
+++ b/src/app/pages/admin/user-details/user-details.component.spec.ts
@@ -411,6 +411,7 @@ describe('UserDetailsComponent', () => {
       extractedUrl: {} as UrlTree,
       trigger: 'imperative',
       previousNavigation: null,
+      abort: () => {},
       extras: {
         state: {
           returnUrl: '/pending-users',

--- a/src/app/pages/admin/user-details/user-details.component.spec.ts
+++ b/src/app/pages/admin/user-details/user-details.component.spec.ts
@@ -411,7 +411,6 @@ describe('UserDetailsComponent', () => {
       extractedUrl: {} as UrlTree,
       trigger: 'imperative',
       previousNavigation: null,
-      abort: jasmine.createSpy('abort'),
       extras: {
         state: {
           returnUrl: '/pending-users',

--- a/src/app/pages/admin/user-details/user-details.component.spec.ts
+++ b/src/app/pages/admin/user-details/user-details.component.spec.ts
@@ -411,7 +411,7 @@ describe('UserDetailsComponent', () => {
       extractedUrl: {} as UrlTree,
       trigger: 'imperative',
       previousNavigation: null,
-      abort: () => {},
+      abort: jasmine.createSpy('abort'),
       extras: {
         state: {
           returnUrl: '/pending-users',

--- a/src/app/pages/admin/user-details/user-details.component.ts
+++ b/src/app/pages/admin/user-details/user-details.component.ts
@@ -221,7 +221,7 @@ export class UserDetailsComponent implements OnInit {
   modalLoading = signal(false);
 
   ngOnInit() {
-    const navigation = this.router.currentNavigation();
+    const navigation = this.router.getCurrentNavigation();
     const stateReturnUrl =
       navigation?.extras?.state?.['returnUrl'] || history.state?.returnUrl;
     if (stateReturnUrl) {

--- a/src/app/pages/user/profile/profile.component.ts
+++ b/src/app/pages/user/profile/profile.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, signal, inject, DOCUMENT } from '@angular/core';
+import { Component, OnInit, signal, inject } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 
 import {
   FormGroup,


### PR DESCRIPTION
## Description

[AAI-828](https://biocloud.atlassian.net/browse/AAI-828): add filter back for SBP admin dashboard

## Changes

- The filter dropdown is now visible for 'platform-bundle' admins (only hidden for 'bundle'),


## Same UI

<img width="3024" height="1748" alt="Screenshot 2026-05-20 at 6 36 15 pm" src="https://github.com/user-attachments/assets/5ea9af4e-1031-4751-bfaa-00c2b84bc1ff" />

## Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added unit / integration tests that prove my fix is effective or that my feature works
- [X] I have run all tests locally and they pass
- [X] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-portal/settings/secrets/actions).



[AAI-828]: https://biocloud.atlassian.net/browse/AAI-828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ