### PR TITLE
fix: typo in biocommons ts and cs

### DIFF
--- a/src/app/pages/terms/biocommons-terms/biocommons-terms.component.html
+++ b/src/app/pages/terms/biocommons-terms/biocommons-terms.component.html
@@ -119,10 +119,10 @@
         </li>
         <li>
           <strong>Administrative Access</strong>: You acknowledge that
-          authorised administrators may access your account to resolve
-          technical issues, either at your request or as required for
-          operational necessity; such access will be conducted in accordance
-          with the Australian BioCommons privacy statement referenced below.
+          authorised administrators may access your account to resolve technical
+          issues, either at your request or as required for operational
+          necessity; such access will be conducted in accordance with the
+          Australian BioCommons privacy statement referenced below.
         </li>
         <li>
           <strong>Indemnity</strong>: You indemnify and hold the Australian

--- a/src/app/pages/terms/biocommons-terms/biocommons-terms.component.html
+++ b/src/app/pages/terms/biocommons-terms/biocommons-terms.component.html
@@ -119,7 +119,7 @@
         </li>
         <li>
           <strong>Administrative Access</strong>: You acknowledge that
-          authoriszed administrators may access your account to resolve
+          authorised administrators may access your account to resolve
           technical issues, either at your request or as required for
           operational necessity; such access will be conducted in accordance
           with the Australian BioCommons privacy statement referenced below.


### PR DESCRIPTION
## Description

[AAI-832](https://biocloud.atlassian.net/browse/AAI-832): Fix typo in updated Biocommons Terms and Conditions

## Changes

- Fixed typo in `src/app/pages/terms/biocommons-terms/biocommons-terms.component.html`

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit / integration tests that prove my fix is effective or that my feature works
- [ ] I have run all tests locally and they pass
- [ ] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-portal/settings/secrets/actions).

## How to Test Manually

All CI tests shall pass.



[AAI-832]: https://biocloud.atlassian.net/browse/AAI-832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ