### PR TITLE
feat: show reminder to sbp bundle user when changing emails

### DIFF
--- a/src/app/core/services/api.service.spec.ts
+++ b/src/app/core/services/api.service.spec.ts
@@ -188,7 +188,7 @@ describe('ApiService', () => {
     });
 
     const req = httpMock.expectOne(
-      `${environment.auth0.backend}/utils/check-australian-research-institution?email=${email}`,
+      `${environment.auth0.backend}/utils/register/check-australian-research-institution?email=${email}`,
     );
     expect(req.request.method).toBe('GET');
     expect(req.request.params.get('email')).toBe(email);

--- a/src/app/core/services/api.service.ts
+++ b/src/app/core/services/api.service.ts
@@ -467,7 +467,7 @@ export class ApiService {
   checkAustralianResearchInstitution(email: string): Observable<boolean> {
     return this.http
       .get<CheckAustralianResearchInstitutionResponse>(
-        `${environment.auth0.backend}/utils/check-australian-research-institution`,
+        `${environment.auth0.backend}/utils/register/check-australian-research-institution`,
         { params: { email } },
       )
       .pipe(map((data) => data.is_australian_research_institution));

--- a/src/app/pages/user/profile/profile.component.html
+++ b/src/app/pages/user/profile/profile.component.html
@@ -128,6 +128,21 @@
                   }
                 </div>
               }
+              @if (sbpEmailNotInstitutional()) {
+                <div class="mt-2 text-xs font-medium text-red-600" role="alert">
+                  Access to the Structural Biology Platform Bundle requires
+                  affiliation with an
+                  <a
+                    href="https://site.usegalaxy.org.au/list-of-institutions.html"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="underline hover:text-red-700"
+                    >Australian Research Institute</a
+                  >. Changing to a non-institutional email address will
+                  automatically revoke access to the SBP workflow execution
+                  bundle
+                </div>
+              }
             </div>
             @if (emailFlowState() === "otp-sent") {
               <div>

--- a/src/app/pages/user/profile/profile.component.spec.ts
+++ b/src/app/pages/user/profile/profile.component.spec.ts
@@ -1,4 +1,9 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
 import { ProfileComponent } from './profile.component';
 import {
   ApiService,
@@ -86,6 +91,7 @@ describe('ProfileComponent', () => {
       'updateName',
       'requestEmailChange',
       'continueEmailChange',
+      'checkAustralianResearchInstitution',
       'deleteAccount',
     ]);
     const authSpy = jasmine.createSpyObj(
@@ -131,6 +137,7 @@ describe('ProfileComponent', () => {
       of({ message: 'OTP sent to the requested email address.' }),
     );
     mockApiService.continueEmailChange.and.returnValue(of(void 0));
+    mockApiService.checkAustralianResearchInstitution.and.returnValue(of(true));
     mockApiService.deleteAccount.and.returnValue(
       of({ message: 'Account deleted successfully' }),
     );
@@ -445,6 +452,177 @@ describe('ProfileComponent', () => {
         'Too many failed attempts. Please wait before trying again or contact the administrators if this issue persists.',
     });
     expect(component.activeModal()).toBeNull();
+  });
+
+  describe('SBP bundle email-change reminder', () => {
+    const sbpReminder =
+      'Access to the Structural Biology Platform Bundle requires';
+
+    const userWithSbp = (
+      approvalStatus: 'approved' | 'pending',
+    ): UserProfileData => ({
+      ...mockUser,
+      group_memberships: [
+        {
+          group_id: 'biocommons/group/sbp_workflow_execution',
+          group_name: 'Structural Biology Platform Bundle',
+          group_short_name: 'SBP',
+          approval_status: approvalStatus,
+        },
+      ],
+    });
+
+    it('reports an approved SBP bundle via hasApprovedSbpBundle()', () => {
+      mockApiService.getUserProfile.and.returnValue(
+        of(userWithSbp('approved')),
+      );
+      fixture.detectChanges();
+
+      expect(
+        (
+          component as unknown as { hasApprovedSbpBundle(): boolean }
+        ).hasApprovedSbpBundle(),
+      ).toBeTrue();
+    });
+
+    it('does not report a pending SBP bundle as approved', () => {
+      mockApiService.getUserProfile.and.returnValue(of(userWithSbp('pending')));
+      fixture.detectChanges();
+
+      expect(
+        (
+          component as unknown as { hasApprovedSbpBundle(): boolean }
+        ).hasApprovedSbpBundle(),
+      ).toBeFalse();
+    });
+
+    it('returns false when the user has no SBP bundle', () => {
+      fixture.detectChanges();
+
+      expect(
+        (
+          component as unknown as { hasApprovedSbpBundle(): boolean }
+        ).hasApprovedSbpBundle(),
+      ).toBeFalse();
+    });
+
+    // Type a new email into the open email modal and let the debounced
+    // institution check resolve (no Send OTP click).
+    const typeNewEmail = (email: string) => {
+      openModal('email');
+      component.emailForm.controls.email.setValue(email);
+      tick(400);
+      fixture.detectChanges();
+    };
+
+    it('shows the red reminder when SBP is approved and the typed email is non-institutional', fakeAsync(() => {
+      mockApiService.getUserProfile.and.returnValue(
+        of(userWithSbp('approved')),
+      );
+      mockApiService.checkAustralianResearchInstitution.and.returnValue(
+        of(false),
+      );
+      fixture.detectChanges();
+
+      typeNewEmail('new@gmail.com');
+
+      expect(
+        mockApiService.checkAustralianResearchInstitution,
+      ).toHaveBeenCalledWith('new@gmail.com');
+      const reminder: HTMLElement | null = (
+        fixture.nativeElement as HTMLElement
+      ).querySelector('.text-red-600');
+      expect(reminder?.textContent).toContain(sbpReminder);
+    }));
+
+    it('does not show the reminder when the typed email is institutional', fakeAsync(() => {
+      mockApiService.getUserProfile.and.returnValue(
+        of(userWithSbp('approved')),
+      );
+      mockApiService.checkAustralianResearchInstitution.and.returnValue(
+        of(true),
+      );
+      fixture.detectChanges();
+
+      typeNewEmail('new@sydney.edu.au');
+
+      expect(component.sbpEmailNotInstitutional()).toBeFalse();
+      expect((fixture.nativeElement as HTMLElement).textContent).not.toContain(
+        sbpReminder,
+      );
+    }));
+
+    it('does not check the email or show the reminder without an approved SBP bundle', fakeAsync(() => {
+      mockApiService.checkAustralianResearchInstitution.and.returnValue(
+        of(false),
+      );
+      fixture.detectChanges();
+
+      typeNewEmail('new@gmail.com');
+
+      expect(
+        mockApiService.checkAustralianResearchInstitution,
+      ).not.toHaveBeenCalled();
+      expect((fixture.nativeElement as HTMLElement).textContent).not.toContain(
+        sbpReminder,
+      );
+    }));
+
+    it('does not call the API for an invalid email', fakeAsync(() => {
+      mockApiService.getUserProfile.and.returnValue(
+        of(userWithSbp('approved')),
+      );
+      fixture.detectChanges();
+
+      typeNewEmail('not-an-email');
+
+      expect(
+        mockApiService.checkAustralianResearchInstitution,
+      ).not.toHaveBeenCalled();
+      expect(component.sbpEmailNotInstitutional()).toBeFalse();
+    }));
+
+    it('does not show the reminder when the institution check errors', fakeAsync(() => {
+      mockApiService.getUserProfile.and.returnValue(
+        of(userWithSbp('approved')),
+      );
+      mockApiService.checkAustralianResearchInstitution.and.returnValue(
+        throwError(() => new Error('network')),
+      );
+      fixture.detectChanges();
+
+      typeNewEmail('new@gmail.com');
+
+      expect(component.sbpEmailNotInstitutional()).toBeFalse();
+      expect((fixture.nativeElement as HTMLElement).textContent).not.toContain(
+        sbpReminder,
+      );
+    }));
+
+    it('hides the reminder again when the email is corrected to institutional', fakeAsync(() => {
+      mockApiService.getUserProfile.and.returnValue(
+        of(userWithSbp('approved')),
+      );
+      mockApiService.checkAustralianResearchInstitution.and.returnValue(
+        of(false),
+      );
+      fixture.detectChanges();
+
+      typeNewEmail('new@gmail.com');
+      expect(component.sbpEmailNotInstitutional()).toBeTrue();
+
+      mockApiService.checkAustralianResearchInstitution.and.returnValue(
+        of(true),
+      );
+      component.emailForm.controls.email.setValue('new@sydney.edu.au');
+      tick(400);
+      fixture.detectChanges();
+
+      expect(component.sbpEmailNotInstitutional()).toBeFalse();
+      expect((fixture.nativeElement as HTMLElement).textContent).not.toContain(
+        sbpReminder,
+      );
+    }));
   });
 
   it('handles a successful password change', () => {

--- a/src/app/pages/user/profile/profile.component.ts
+++ b/src/app/pages/user/profile/profile.component.ts
@@ -1,5 +1,6 @@
 import { DOCUMENT } from '@angular/common';
-import { Component, OnInit, signal, inject } from '@angular/core';
+import { Component, DestroyRef, OnInit, signal, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import {
   FormGroup,
@@ -45,7 +46,14 @@ import {
   heroUser,
 } from '@ng-icons/heroicons/outline';
 import { HttpClient } from '@angular/common/http';
-import { catchError, of } from 'rxjs';
+import {
+  catchError,
+  debounceTime,
+  distinctUntilChanged,
+  map,
+  of,
+  switchMap,
+} from 'rxjs';
 import { DataRefreshService } from '../../../core/services/data-refresh.service';
 import { FormControl } from '@angular/forms';
 
@@ -84,6 +92,7 @@ export class ProfileComponent implements OnInit {
   private document = inject(DOCUMENT);
   private validationService = inject(ValidationService);
   private formBuilder = inject(FormBuilder);
+  private destroyRef = inject(DestroyRef);
 
   protected readonly platforms = PLATFORMS;
   protected readonly bundles = BIOCOMMONS_BUNDLES;
@@ -127,6 +136,9 @@ export class ProfileComponent implements OnInit {
   otpLoading = signal(false);
   otpError = signal<string | null>(null);
   emailModalNotice = signal<string | null>(null);
+  // True only when the user holds an approved SBP bundle AND the new email is
+  // confirmed to NOT be from an Australian research institution.
+  sbpEmailNotInstitutional = signal(false);
 
   passwordForm = this.formBuilder.nonNullable.group({
     currentPassword: ['', Validators.required],
@@ -162,6 +174,37 @@ export class ProfileComponent implements OnInit {
         this.validationService.clearFieldBackendError('username');
       }
     });
+    this.watchEmailInstitutionStatus();
+  }
+
+  /**
+   * Live-check the new email as the user types: when they hold an approved SBP
+   * bundle and enter a valid, non-institutional email, show the revocation
+   * reminder — without waiting for the OTP to be sent. On any error we leave the
+   * reminder hidden rather than warn on an inconclusive check.
+   */
+  private watchEmailInstitutionStatus(): void {
+    const emailControl = this.emailForm.get('email');
+    if (!emailControl) return;
+
+    emailControl.valueChanges
+      .pipe(
+        debounceTime(400),
+        map((value) => toAsciiEmail((value ?? '').trim())),
+        distinctUntilChanged(),
+        switchMap((email) => {
+          if (!email || emailControl.invalid || !this.hasApprovedSbpBundle()) {
+            return of(true);
+          }
+          return this.apiService
+            .checkAustralianResearchInstitution(email)
+            .pipe(catchError(() => of(true)));
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe((isInstitution) => {
+        this.sbpEmailNotInstitutional.set(!isInstitution);
+      });
   }
 
   protected openModal(type: ProfileModal): void {
@@ -223,6 +266,7 @@ export class ProfileComponent implements OnInit {
     this.emailLoading.set(false);
     this.otpLoading.set(false);
     this.emailModalNotice.set(null);
+    this.sbpEmailNotInstitutional.set(false);
   }
 
   protected closeModal(): void {
@@ -561,6 +605,19 @@ export class ProfileComponent implements OnInit {
     const bundleId = groupId.split('/').pop() || '';
     const bundle = this.bundles.find((b) => b.id === bundleId);
     return bundle?.logoUrls || [];
+  }
+
+  /**
+   * Whether the current user holds an approved SBP Workflow Execution bundle.
+   * Used to warn the user, when changing their email, that switching to a
+   * non-institutional email will revoke their SBP bundle access.
+   */
+  protected hasApprovedSbpBundle(): boolean {
+    return !!this.user()?.group_memberships?.some(
+      (membership) =>
+        membership.group_id.split('/').pop() === 'sbp_workflow_execution' &&
+        membership.approval_status === 'approved',
+    );
   }
 
   deleteAccountBegin(): void {


### PR DESCRIPTION
## Description

[SBP-398](https://biocloud.atlassian.net/browse/SBP-398): Warn users that changing to a non-institutional email revokes their SBP bundle

## Changes
- Adds a live check on the Change email modal: as the user types a new email, debounced (400ms) call to the institution API determines if it's an Australian research institution.
- Shows a red reminder under the New email field — only when the user holds an approved SBP bundle AND the typed email is confirmed non-institutional. Message links "Australian Research Institute" to the [Galaxy institutions list](https://site.usegalaxy.org.au/list-of-institutions.html).
- Reminder updates live (no Send OTP click needed) and clears when the email is corrected to an institutional one; hidden on invalid email or API error.
- Fixes a latent bug: `checkAustralianResearchInstitution()` pointed at `/utils/check-australian-research-institution`, corrected to the real backend route `/utils/register/check-australian-research-institution`.
- Adds `hasApprovedSbpBundle()` helper + `sbpEmailNotInstitutional` signal; subscription cleaned up via `takeUntilDestroyed`.

Related backend changes: https://github.com/AustralianBioCommons/aai-backend/pull/278

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-portal/settings/secrets/actions).

## How to Test Manually

All tests in CI shall pass

## Screenshots for any UI changes

<img width="1511" height="814" alt="Screenshot 2026-06-10 at 3 03 31 pm" src="https://github.com/user-attachments/assets/68d08a57-8b37-4b2f-8716-afc93f7e026a" />



[SBP-398]: https://biocloud.atlassian.net/browse/SBP-398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ