### PR TITLE
fix: SBP login launch

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -35,6 +35,9 @@ export const appConfig: ApplicationConfig = {
       },
       cacheLocation: 'localstorage',
       useRefreshTokens: true,
+      // Fall back to silent iframe auth when no refresh token is cached (e.g.
+      // before login) instead of throwing a "Missing Refresh Token" error.
+      useRefreshTokensFallback: true,
     }),
     provideHttpClient(withInterceptors([authInterceptor])),
     provideZoneChangeDetection({ eventCoalescing: true }),

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -31,8 +31,10 @@ export const appConfig: ApplicationConfig = {
       clientId: '',
       authorizationParams: {
         redirect_uri: window.location.origin,
+        scope: 'openid profile email offline_access',
       },
       cacheLocation: 'localstorage',
+      useRefreshTokens: true,
     }),
     provideHttpClient(withInterceptors([authInterceptor])),
     provideZoneChangeDetection({ eventCoalescing: true }),

--- a/src/app/core/config/runtime-config-loader.service.ts
+++ b/src/app/core/config/runtime-config-loader.service.ts
@@ -37,8 +37,12 @@ export class RuntimeConfigLoaderService {
               clientId: merged.auth0.clientId,
               authorizationParams: {
                 redirect_uri: merged.auth0.redirectUri,
+                scope: 'openid profile email offline_access',
               },
               cacheLocation: 'localstorage',
+              // Rotating refresh tokens keep the SSO session alive without
+              // depending on third-party-cookie iframe checks.
+              useRefreshTokens: true,
             });
           }),
         ),

--- a/src/app/core/config/runtime-config-loader.service.ts
+++ b/src/app/core/config/runtime-config-loader.service.ts
@@ -43,6 +43,9 @@ export class RuntimeConfigLoaderService {
               // Rotating refresh tokens keep the SSO session alive without
               // depending on third-party-cookie iframe checks.
               useRefreshTokens: true,
+              // Fall back to silent iframe auth when no refresh token is cached
+              // (e.g. before login) instead of throwing "Missing Refresh Token".
+              useRefreshTokensFallback: true,
             });
           }),
         ),

--- a/src/app/pages/user/profile/profile.component.ts
+++ b/src/app/pages/user/profile/profile.component.ts
@@ -356,7 +356,11 @@ export class ProfileComponent implements OnInit {
     }
 
     if (platformId !== 'galaxy') {
-      windowRef.open(launchUrl, '_blank');
+      // SBP performs a seamless SSO login when launched with `login=true`; it
+      // does a full-page Auth0 redirect that reuses the existing SSO session.
+      const targetUrl =
+        platformId === 'sbp' ? this.withLoginFlag(launchUrl) : launchUrl;
+      windowRef.open(targetUrl, '_blank');
       return;
     }
 
@@ -384,6 +388,16 @@ export class ProfileComponent implements OnInit {
           windowRef.open(launchUrl, '_blank');
         }
       });
+  }
+
+  private withLoginFlag(url: string): string {
+    try {
+      const parsed = new URL(url);
+      parsed.searchParams.set('login', 'true');
+      return parsed.toString();
+    } catch {
+      return url;
+    }
   }
 
   protected updateName(): void {


### PR DESCRIPTION
## Description

[AAI-825](https://biocloud.atlassian.net/browse/AAI-825):  fix: launch SBP with SSO auto-login flag

## Changes

- SBP launch now appends `login=true` so SBP can trigger a seamless full-page SSO login (new `withLoginFlag()` helper)
- Enables `useRefreshTokens` + offline_access scope in the Auth0 config (static + runtime loader) to keep the SSO session alive without third-party-cookie iframe checks

Related Pull Request in SBP: https://github.com/AustralianBioCommons/sbp-portal/pull/87

## Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added unit / integration tests that prove my fix is effective or that my feature works
- [X] I have run all tests locally and they pass
- [X] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-portal/settings/secrets/actions).

## How to Test Manually

CI tests shall pass!



[AAI-825]: https://biocloud.atlassian.net/browse/AAI-825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ