### PR TITLE
feat: split sbp admin

### DIFF
--- a/src/app/core/constants/constants.ts
+++ b/src/app/core/constants/constants.ts
@@ -66,12 +66,3 @@ export const BIOCOMMONS_BUNDLES: Bundle[] = [
     ],
   },
 ];
-
-/**
- * Maps platform IDs to the bundle group ID whose admin access is granted by
- * the same Auth0 role as the platform admin role (biocommons/role/{platform}/admin).
- * Mirrors the backend PLATFORM_BUNDLE_GROUP_MAP in scheduled_tasks/tasks.py.
- */
-export const PLATFORM_BUNDLE_GROUP_MAP: Partial<Record<PlatformId, string>> = {
-  sbp: 'biocommons/group/sbp_workflow_execution',
-};

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -14,14 +14,8 @@ import {
 } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { AdminPlatformResponse, AdminGroupResponse } from './api.service';
-import { PLATFORM_BUNDLE_GROUP_MAP } from '../constants/constants';
 
-export type AdminType =
-  | 'biocommons'
-  | 'platform'
-  | 'platform-bundle'
-  | 'bundle'
-  | null;
+export type AdminType = 'biocommons' | 'platform' | 'bundle' | null;
 
 export interface AuthError {
   error: string;
@@ -151,18 +145,6 @@ export class AuthService {
 
     const platforms = this.adminPlatforms();
     const groups = this.adminGroups();
-
-    // Platform-bundle admin: single platform whose groups are exactly its
-    // associated bundles (e.g. SBP admin). Detected before 'biocommons' so it
-    // doesn't inherit the broader biocommons privileges in the UI.
-    if (
-      platforms.length === 1 &&
-      groups.length > 0 &&
-      groups.every((g) =>
-        platforms.some((p) => PLATFORM_BUNDLE_GROUP_MAP[p.id] === g.id),
-      )
-    )
-      return 'platform-bundle';
 
     // BioCommons admin: manages multiple platforms or both platforms and groups
     if (platforms.length > 1 || (platforms.length && groups.length))

--- a/src/app/pages/admin/components/user-list/user-list.component.html
+++ b/src/app/pages/admin/components/user-list/user-list.component.html
@@ -145,11 +145,7 @@
     >
       <div
         class="flex-1"
-        [ngClass]="
-          adminType() !== 'bundle' && adminType() !== 'platform-bundle'
-            ? 'w-6/12'
-            : 'w-8/12'
-        "
+        [ngClass]="adminType() !== 'bundle' ? 'w-6/12' : 'w-8/12'"
       >
         Total:
         <span class="font-light text-gray-300">{{ totalUsers() }} users</span>
@@ -169,8 +165,7 @@
             {{
               adminType() === "biocommons"
                 ? "Services"
-                : adminType() === "platform" ||
-                    adminType() === "platform-bundle"
+                : adminType() === "platform"
                   ? adminPlatforms()[0].name + " Access"
                   : "Access"
             }}
@@ -402,8 +397,7 @@
                       track platform.id
                     ) {
                       @if (
-                        (adminType() === "platform" ||
-                          adminType() === "platform-bundle") &&
+                        adminType() === "platform" &&
                         platform.platform_id === adminPlatforms()[0].id
                       ) {
                         <div
@@ -492,8 +486,7 @@
                         platform.approval_status === "approved" &&
                         ((adminType() === "biocommons" &&
                           user.platform_memberships.length === 1) ||
-                          ((adminType() === "platform" ||
-                            adminType() === "platform-bundle") &&
+                          (adminType() === "platform" &&
                             platform.platform_id === adminPlatforms()[0].id))
                       ) {
                         <button
@@ -531,7 +524,6 @@
                       !isCurrentAdminUser(user.id) &&
                       !user.email_verified &&
                       (adminType() === "platform" ||
-                        adminType() === "platform-bundle" ||
                         adminType() === "biocommons")
                     ) {
                       <button

--- a/src/app/pages/admin/user-details/user-details.component.html
+++ b/src/app/pages/admin/user-details/user-details.component.html
@@ -185,10 +185,7 @@
                   Resend Verification Email
                 </button>
               }
-              @if (
-                adminType() === "platform" ||
-                adminType() === "biocommons"
-              ) {
+              @if (adminType() === "platform" || adminType() === "biocommons") {
                 <button
                   class="flex w-full items-center gap-2 px-4 py-2 text-sm text-gray-700 transition-all hover:bg-gray-100 hover:text-gray-900"
                   role="menuitem"

--- a/src/app/pages/admin/user-details/user-details.component.html
+++ b/src/app/pages/admin/user-details/user-details.component.html
@@ -155,7 +155,6 @@
         @let showActionButton =
           !user()?.email_verified ||
           adminType() === "platform" ||
-          adminType() === "platform-bundle" ||
           adminType() === "biocommons";
         @if (showActionButton) {
           <app-dropdown-menu
@@ -188,7 +187,6 @@
               }
               @if (
                 adminType() === "platform" ||
-                adminType() === "platform-bundle" ||
                 adminType() === "biocommons"
               ) {
                 <button

--- a/src/app/shared/components/navbar/navbar.component.ts
+++ b/src/app/shared/components/navbar/navbar.component.ts
@@ -135,10 +135,7 @@ export class NavbarComponent {
 
     if (this.adminType() === 'biocommons') {
       return `BioCommons Admin ${suffix}`;
-    } else if (
-      this.adminType() === 'platform' ||
-      this.adminType() === 'platform-bundle'
-    ) {
+    } else if (this.adminType() === 'platform') {
       return `${this.adminPlatforms()[0].name} Admin ${suffix}`;
     }
 


### PR DESCRIPTION
## Description

[AAI-856](https://biocloud.atlassian.net/browse/AAI-856): Split SBP admin to service and bundle admin

## Changes

- removed the `'platform-bundle'` `AdminType` and its detection, plus the mirrored `PLATFORM_BUNDLE_GROUP_MAP`.
- An SBP service admin now resolves to 'platform' and an SBP bundle admin to 'bundle' — each already has its own admin dashboard view. 
- Cleaned up all 'platform-bundle' branches in navbar, user-list, and user-details. 

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-portal/settings/secrets/actions).

## How to Test Manually

All CI tests shall pass.

[AAI-856]: https://biocloud.atlassian.net/browse/AAI-856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ