### PR TITLE
chore: update Galaxy launch URL to Auth0 (AAI-857)

### DIFF
--- a/src/app/pages/user/profile/profile.component.ts
+++ b/src/app/pages/user/profile/profile.component.ts
@@ -367,7 +367,7 @@ export class ProfileComponent implements OnInit {
     const normalizedBase = launchUrl.endsWith('/')
       ? launchUrl
       : `${launchUrl}/`;
-    const loginEndpoint = `${normalizedBase}authnz/oidc/login`;
+    const loginEndpoint = `${normalizedBase}authnz/auth0/login`;
 
     this.httpClient
       .get<{ redirect_uri?: string }>(loginEndpoint)


### PR DESCRIPTION
## Description

[AAI-857](https://biocloud.atlassian.net/browse/AAI-857): the OIDC provider in Galaxy is now called `auth0`, the Galaxy launch URL needs to be updated to reflect this.


## Changes

- Update Galaxy launch URL (for profile "Launch" button)


[AAI-857]: https://biocloud.atlassian.net/browse/AAI-857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ