### PR TITLE
style: make stepper on registration page smaller

### DIFF
--- a/src/app/pages/register/register.component.html
+++ b/src/app/pages/register/register.component.html
@@ -71,7 +71,7 @@
                       (click)="scrollToSection($event, section.id)"
                     >
                       <div
-                        class="relative z-10 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full border-2 transition-all"
+                        class="relative z-10 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full border-2 transition-all"
                         [ngClass]="{
                           'border-gray-300': !visited,
                           'border-biocommons-primary group-hover:border-sky-900':
@@ -93,7 +93,8 @@
                         } @else if (last && active && valid) {
                           <ng-icon
                             name="heroCheck"
-                            size="20"
+                            size="16"
+                            strokeWidth="2"
                             class="z-10 text-white"
                           ></ng-icon>
                         } @else if (active) {
@@ -103,7 +104,8 @@
                         } @else if (completed && valid) {
                           <ng-icon
                             name="heroCheck"
-                            size="20"
+                            size="16"
+                            strokeWidth="2"
                             class="z-10 text-white"
                           ></ng-icon>
                         } @else if (completed && !valid) {
@@ -111,7 +113,8 @@
                         } @else if (visited && valid) {
                           <ng-icon
                             name="heroCheck"
-                            size="20"
+                            size="16"
+                            strokeWidth="2"
                             class="text-biocommons-primary"
                           ></ng-icon>
                         } @else if (visited && !valid) {
@@ -124,7 +127,7 @@
                   <!-- Connecting line -->
                   @if (index < sections.length - 1) {
                     <div
-                      class="absolute left-1/2 top-4 h-0.5 w-full transition-all"
+                      class="absolute left-1/2 top-3 h-0.5 w-full transition-all"
                       [class]="
                         completed ? 'bg-biocommons-primary' : 'bg-gray-300'
                       "

--- a/src/app/pages/register/register.component.html
+++ b/src/app/pages/register/register.component.html
@@ -71,7 +71,7 @@
                       (click)="scrollToSection($event, section.id)"
                     >
                       <div
-                        class="relative z-10 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full border-2 transition-all"
+                        class="relative z-10 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full border-2 text-sm font-medium transition-all"
                         [ngClass]="{
                           'border-gray-300': !visited,
                           'border-biocommons-primary group-hover:border-sky-900':
@@ -93,8 +93,8 @@
                         } @else if (last && active && valid) {
                           <ng-icon
                             name="heroCheck"
-                            size="16"
-                            strokeWidth="2"
+                            size="14"
+                            strokeWidth="2.5"
                             class="z-10 text-white"
                           ></ng-icon>
                         } @else if (active) {
@@ -104,8 +104,8 @@
                         } @else if (completed && valid) {
                           <ng-icon
                             name="heroCheck"
-                            size="16"
-                            strokeWidth="2"
+                            size="14"
+                            strokeWidth="2.5"
                             class="z-10 text-white"
                           ></ng-icon>
                         } @else if (completed && !valid) {
@@ -113,8 +113,8 @@
                         } @else if (visited && valid) {
                           <ng-icon
                             name="heroCheck"
-                            size="16"
-                            strokeWidth="2"
+                            size="14"
+                            strokeWidth="2.5"
                             class="text-biocommons-primary"
                           ></ng-icon>
                         } @else if (visited && !valid) {


### PR DESCRIPTION
Tiny PR to make the stepper on registration page a bit smaller to be more more proportionate & take up less vertical space (will also be the same size as the SBP portal's workflow form progress bar)

Before:
<img width="1512" height="774" alt="image" src="https://github.com/user-attachments/assets/bf8ceb08-305b-4076-b9d7-6cc5885c9639" />

After:
<img width="1512" height="774" alt="image" src="https://github.com/user-attachments/assets/93447c36-1322-4643-94f3-b6640cd5875c" />

